### PR TITLE
Use quickselect to significantly speed up median and quantile

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/simple-statistics/simple-statistics.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "quickselect": "^1.0.0"
+  },
   "devDependencies": {
     "are-we-flow-yet": "^1.0.0",
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "type": "git",
     "url": "git://github.com/simple-statistics/simple-statistics.git"
   },
-  "dependencies": {
-    "quickselect": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "are-we-flow-yet": "^1.0.0",
     "browserify": "^13.0.0",

--- a/src/median.js
+++ b/src/median.js
@@ -1,8 +1,7 @@
 'use strict';
 /* @flow */
 
-var medianSorted = require('./median_sorted'),
-    numericSort = require('./numeric_sort');
+var quickselect = require('quickselect');
 
 /**
  * The [median](http://en.wikipedia.org/wiki/Median) is
@@ -22,9 +21,28 @@ var medianSorted = require('./median_sorted'),
  * median(incomes); //= 3.5
  */
 function median(x /*: Array<number> */)/*:number*/ {
-    // Sorting the array makes it easy to find the center, but
-    // use `.slice()` to ensure the original array `x` is not modified
-    return medianSorted(numericSort(x));
+    // The median of an empty list is NaN
+    if (x.length === 0) { return NaN; }
+
+    var copy = x.slice();
+    var k;
+
+    // If the length of the list is odd, it's the central number
+    if (x.length % 2 === 1) {
+        k = (x.length - 1) / 2;
+        // Rearrange so that k-th element is k-th smallest
+        quickselect(copy, k);
+        return copy[k];
+
+    // Otherwise, the median is the average of the two numbers at the center of the list
+    } else {
+        k = x.length / 2 - 1;
+        // Rearrange so that k-th element is k-th smallest
+        quickselect(copy, k);
+        // Rearrange the remaining half so that the first element is smallest
+        quickselect(copy, k + 1, k + 1);
+        return (copy[k] + copy[k + 1]) / 2;
+    }
 }
 
 module.exports = median;

--- a/src/median.js
+++ b/src/median.js
@@ -1,7 +1,7 @@
 'use strict';
 /* @flow */
 
-var quickselect = require('quickselect');
+var quantile = require('./quantile');
 
 /**
  * The [median](http://en.wikipedia.org/wiki/Median) is
@@ -21,28 +21,7 @@ var quickselect = require('quickselect');
  * median(incomes); //= 3.5
  */
 function median(x /*: Array<number> */)/*:number*/ {
-    // The median of an empty list is NaN
-    if (x.length === 0) { return NaN; }
-
-    var copy = x.slice();
-    var k;
-
-    // If the length of the list is odd, it's the central number
-    if (x.length % 2 === 1) {
-        k = (x.length - 1) / 2;
-        // Rearrange so that k-th element is k-th smallest
-        quickselect(copy, k);
-        return copy[k];
-
-    // Otherwise, the median is the average of the two numbers at the center of the list
-    } else {
-        k = x.length / 2 - 1;
-        // Rearrange so that k-th element is k-th smallest
-        quickselect(copy, k);
-        // Rearrange the remaining half so that the first element is smallest
-        quickselect(copy, k + 1, k + 1);
-        return (copy[k] + copy[k + 1]) / 2;
-    }
+    return +quantile(x, 0.5);
 }
 
 module.exports = median;

--- a/src/median_sorted.js
+++ b/src/median_sorted.js
@@ -1,6 +1,8 @@
 'use strict';
 /* @flow */
 
+var quantileSorted = require('./quantile_sorted');
+
 /**
  * The [median](http://en.wikipedia.org/wiki/Median) is
  * the middle number of a list. This is often a good indicator of 'the middle'
@@ -19,19 +21,7 @@
  * median(incomes); //= 3.5
  */
 function medianSorted(sorted /*: Array<number> */)/*:number*/ {
-    // The median of an empty list is NaN
-    if (sorted.length === 0) { return NaN; }
-
-    // If the length of the list is odd, it's the central number
-    if (sorted.length % 2 === 1) {
-        return sorted[(sorted.length - 1) / 2];
-    // Otherwise, the median is the average of the two numbers
-    // at the center of the list
-    } else {
-        var a = sorted[sorted.length / 2 - 1];
-        var b = sorted[sorted.length / 2];
-        return (a + b) / 2;
-    }
+    return quantileSorted(sorted, 0.5);
 }
 
 module.exports = medianSorted;

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -2,7 +2,7 @@
 /* @flow */
 
 var quantileSorted = require('./quantile_sorted');
-var quickselect = require('quickselect');
+var quickselect = require('./quickselect');
 
 /**
  * The [quantile](https://en.wikipedia.org/wiki/Quantile):

--- a/src/quickselect.js
+++ b/src/quickselect.js
@@ -25,6 +25,7 @@ function quickselect(arr /*: Array<number> */, k /*: number */, left /*: number 
     right = right || (arr.length - 1);
 
     while (right > left) {
+        // 600 and 0.5 are arbitrary constants chosen in the original paper to minimize execution time
         if (right - left > 600) {
             var n = right - left + 1;
             var m = k - left + 1;

--- a/src/quickselect.js
+++ b/src/quickselect.js
@@ -1,0 +1,70 @@
+'use strict';
+/* @flow */
+
+module.exports = quickselect;
+
+/**
+ * Rearrange items in `arr` so that all items in `[left, k]` range are the smallest.
+ * The `k`-th element will have the `(k - left + 1)`-th smallest value in `[left, right]`.
+ *
+ * Implements Floyd-Rivest selection algorithm https://en.wikipedia.org/wiki/Floyd-Rivest_algorithm
+ *
+ * @private
+ * @param {Array<number>} arr input array
+ * @param {number} k pivot index
+ * @param {number} left left index
+ * @param {number} right right index
+ * @returns {undefined}
+ * @example
+ * var arr = [65, 28, 59, 33, 21, 56, 22, 95, 50, 12, 90, 53, 28, 77, 39];
+ * quickselect(arr, 8);
+ * // [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]
+ */
+function quickselect(arr /*: Array<number> */, k /*: number */, left /*: number */, right /*: number */) {
+    left = left || 0;
+    right = right || (arr.length - 1);
+
+    while (right > left) {
+        if (right - left > 600) {
+            var n = right - left + 1;
+            var m = k - left + 1;
+            var z = Math.log(n);
+            var s = 0.5 * Math.exp(2 * z / 3);
+            var sd = 0.5 * Math.sqrt(z * s * (n - s) / n);
+            if (m - n / 2 < 0) sd *= -1;
+            var newLeft = Math.max(left, Math.floor(k - m * s / n + sd));
+            var newRight = Math.min(right, Math.floor(k + (n - m) * s / n + sd));
+            quickselect(arr, k, newLeft, newRight);
+        }
+
+        var t = arr[k];
+        var i = left;
+        var j = right;
+
+        swap(arr, left, k);
+        if (arr[right] > t) swap(arr, left, right);
+
+        while (i < j) {
+            swap(arr, i, j);
+            i++;
+            j--;
+            while (arr[i] < t) i++;
+            while (arr[j] > t) j--;
+        }
+
+        if (arr[left] === t) swap(arr, left, j);
+        else {
+            j++;
+            swap(arr, j, right);
+        }
+
+        if (j <= k) left = j + 1;
+        if (k <= j) right = j - 1;
+    }
+}
+
+function swap(arr, i, j) {
+    var tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+}

--- a/test/median.test.js
+++ b/test/median.test.js
@@ -21,7 +21,7 @@ test('median', function(t) {
         t.end();
     });
 
-    t.test('gives null for the median of an empty list', function(t) {
+    t.test('gives NaN for the median of an empty list', function(t) {
         t.ok(isNaN(ss.median([])));
         t.end();
     });

--- a/test/quickselect.test.js
+++ b/test/quickselect.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var test = require('tap').test;
+var quickselect = require('../src/quickselect');
+
+test('quickselect', function (t) {
+    var arr = [65, 28, 59, 33, 21, 56, 22, 95, 50, 12, 90, 53, 28, 77, 39];
+    quickselect(arr, 8);
+    t.deepEqual(arr, [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]);
+    t.end();
+});
+
+test('quickselect long arrays', function (t) {
+    var arr = [];
+    for (var i = 1000; i >= 0; i--) arr.push(i);
+    quickselect(arr, 300);
+    t.equal(arr[300], 300);
+    t.end();
+});


### PR DESCRIPTION
A work in progress, closes #145. The first commit implements median using quickselect, making it much faster — from `O(N log N)` to `O(N)` for unsorted input.

For a sample benchmark on 1 million random numbers, the current implementation runs in 755ms. The new one is 28ms — 27 times faster.

Remaining tasks if the approach is approved:

- [x] rewrite quantile using quickselection
- [x] pull quickselect into the repo
- [ ] clean up new quantile implementation, add comments
- [ ] add `nthElement` to the API (a generalization of `min` and `max` for any `n`)

cc @tmcw HAPPY BIRTHDAY!!! :cake: :cake: :cake: 