### PR TITLE
Use jsdoctest@^1.6.1 and fix the flow tests

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+.*/node_modules/config-chain/test/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "^2.4.0",
     "exorcist": "^0.4.0",
     "flow-bin": "^0.22.0",
-    "jsdoctest": "1.6.0",
+    "jsdoctest": "1.6.1",
     "mocha": "2.5.3",
     "random-js": "^1.0.4",
     "tap": "^5.7.0",
@@ -32,7 +32,7 @@
     "prepublish": "npm run build",
     "bundle": "mkdir -p dist && browserify -p bundle-collapser/plugin -s ss index.js --debug | exorcist dist/simple-statistics.js.map > dist/simple-statistics.js",
     "minify": "uglifyjs dist/simple-statistics.js -c -m --in-source-map=dist/simple-statistics.js.map --source-map=dist/simple-statistics.min.js.map -o dist/simple-statistics.min.js",
-    "jsdoctest": "set -e\nfor f in src/*.js\ndo\n./node_modules/.bin/mocha --require jsdoctest $f\ndone"
+    "jsdoctest": "mocha --require jsdoctest index.js"
   },
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Adds `.+/node_modules/config-chain/test/.+` to the flow ignored files and uses
jsdoctest@^1.6.1 with _"inter-requiring modules have trouble with the
first-require trick"_ (yamadapc/jsdoctest#26) fixed.