### PR TITLE
Combinations with replacement

### DIFF
--- a/scripts/required_test.js
+++ b/scripts/required_test.js
@@ -37,6 +37,7 @@ require("../test/unique_count_sorted.test.js");
 require("../test/standard_deviation.test.js");
 require("../test/standard_normal_table.js");
 require("../test/sum.test.js");
+require("../test/combinationsReplacement.js");
 require("../test/sum_nth_power_deviations.test.js");
 require("../test/t_test.test.js");
 require("../test/t_test_two_sample.test.js");

--- a/src/combinationsReplacement.js
+++ b/src/combinationsReplacement.js
@@ -1,0 +1,38 @@
+/* @flow */
+'use strict';
+/**
+ * Implementation of Combinations with replacement
+ * Combinations are unique subsets of a collection - in this case, k elements from a collection at a time.
+ * With replacement implies that a given element can be chosen multiple times.
+ * Order is unimportant.
+ * https://en.wikipedia.org/wiki/Combination
+ * @param {Array} elements any type of data
+ * @param {int} k the number of objects in each group (without replacement)
+ * @returns {Array<Array>} array of permutations
+ * @example
+ * combinationsReplacement([1, 2], 2); // => [[1,1], [1,2], [2,2]]
+ */
+
+function combinationsReplacement(elements /*: Array<any> */, k/*: number */){
+  var i;
+  var subI;
+  var combinationList = [];
+  var subsetCombinations;
+  var next;
+
+  for (i = 0; i < elements.length; i++){
+    if (k === 1){
+      combinationList.push([ elements[i] ])
+    } else {
+      subsetCombinations = combinationsReplacement(elements.slice(i, elements.length), k-1);
+      for (subI = 0; subI < subsetCombinations.length; subI++){
+        next = subsetCombinations[subI];
+        next.unshift(elements[i]);
+        combinationList.push(next);
+      }
+    }
+  }
+  return combinationList;
+}
+
+module.exports = combinationsReplacement;

--- a/test/combinationsReplacement.test.js
+++ b/test/combinationsReplacement.test.js
@@ -1,0 +1,21 @@
+/* eslint no-shadow: 0 */
+'use strict';
+
+var test = require('tap').test;
+var ss = require('../');
+
+test('combinations', function(t) {
+    t.test('generates 1 permutation', function(t) {
+        t.deepEqual(ss.combinationsReplacement([1], 1), [[1]]);
+        t.end();
+    });
+    t.test('generates combinations of 1,2 choosing two at a time, with replacement', function(t) {
+        t.deepEqual(ss.combinationsReplacement([1, 2], 2), [
+            [1,1],
+            [1,2],
+            [2,2]
+        ]);
+        t.end();
+    });
+    t.end();
+});


### PR DESCRIPTION
Modified the algorithm I wrote to do combinations without replacement, but with replacement.

Turns out it was a pretty small fix.

Maybe it'd be preferable to just merge both of these into one file and have an argument for whether replacement should be considered or not? I'll leave that design choice up to you. 