### PR TITLE
Fixing build

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/config-chain/test/.*
+.*/node_modules/conventional-changelog-core/test/.*
 .*/node_modules/.cache.*
 
 [include]


### PR DESCRIPTION
A file from the `conventional-changelog-core` package was breaking `flow check`.