### PR TITLE
Throw errors rather than returning NaN

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,3 +123,19 @@ space between expressions. No hard tabs.
   `(!foo)`.
 * Straightforward code is more important than most optimizations.
 
+## Errors
+
+Simple statistics emits errors for incorrect input. Error messages are modeled
+after the Python `statistics` package. Many of the errors are related to the size
+of the input sample, and follow this format:
+
+    FUNCTION requires at least N data point(s)
+
+For example:
+
+    min requires at least one data point
+
+The following should be true of all errors:
+
+* Errors are not sentences, and they do not end in periods.
+* When referring to numbers, use APA style - words for numbers under 10

--- a/src/bernoulli_distribution.js
+++ b/src/bernoulli_distribution.js
@@ -21,7 +21,9 @@ var binomialDistribution = require('./binomial_distribution');
  */
 function bernoulliDistribution(p/*: number */) {
     // Check that `p` is a valid probability (0 ≤ p ≤ 1)
-    if (p < 0 || p > 1 ) { return NaN; }
+    if (p < 0 || p > 1 ) {
+        throw new Error('bernoulliDistribution requires probalility to be between 0 and 1 inclusive');
+    }
 
     return binomialDistribution(1, p);
 }

--- a/src/bernoulli_distribution.js
+++ b/src/bernoulli_distribution.js
@@ -22,7 +22,7 @@ var binomialDistribution = require('./binomial_distribution');
 function bernoulliDistribution(p/*: number */) {
     // Check that `p` is a valid probability (0 ≤ p ≤ 1)
     if (p < 0 || p > 1 ) {
-        throw new Error('bernoulliDistribution requires probalility to be between 0 and 1 inclusive');
+        throw new Error('bernoulliDistribution requires probability to be between 0 and 1 inclusive');
     }
 
     return binomialDistribution(1, p);

--- a/src/bernoulli_distribution.js
+++ b/src/bernoulli_distribution.js
@@ -16,6 +16,7 @@ var binomialDistribution = require('./binomial_distribution');
  *
  * @param {number} p input value, between 0 and 1 inclusive
  * @returns {number} value of bernoulli distribution at this point
+ * @throws {Error} if p is outside 0 and 1
  * @example
  * bernoulliDistribution(0.5); // => { '0': 0.5, '1': 0.5 }
  */

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -7,17 +7,17 @@
  * function, and thus will insert smaller-sized chunks at the end if
  * the input size is not divisible by the chunk size.
  *
- * `sample` is expected to be an array, and `chunkSize` a number.
- * The `sample` array can contain any kind of data.
+ * `x` is expected to be an array, and `chunkSize` a number.
+ * The `x` array can contain any kind of data.
  *
- * @param {Array} sample any array of values
- * @param {number} chunkSize size of each output array
+ * @param {Array} x a sample
+ * @param {number} chunkSize size of each output array. must be a positive integer
  * @returns {Array<Array>} a chunked array
  * @example
  * chunk([1, 2, 3, 4, 5, 6], 2);
  * // => [[1, 2], [3, 4], [5, 6]]
  */
-function chunk(sample/*:Array<any>*/, chunkSize/*:number*/)/*:?Array<Array<any>>*/ {
+function chunk(x/*:Array<any>*/, chunkSize/*:number*/)/*:?Array<Array<any>>*/ {
 
     // a list of result chunks, as arrays in an array
     var output = [];
@@ -32,12 +32,12 @@ function chunk(sample/*:Array<any>*/, chunkSize/*:number*/)/*:?Array<Array<any>>
 
     // `start` is the index at which `.slice` will start selecting
     // new array elements
-    for (var start = 0; start < sample.length; start += chunkSize) {
+    for (var start = 0; start < x.length; start += chunkSize) {
 
         // for each chunk, slice that part of the array and add it
         // to the output. The `.slice` function does not change
         // the original array.
-        output.push(sample.slice(start, start + chunkSize));
+        output.push(x.slice(start, start + chunkSize));
     }
     return output;
 }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -13,6 +13,7 @@
  * @param {Array} x a sample
  * @param {number} chunkSize size of each output array. must be a positive integer
  * @returns {Array<Array>} a chunked array
+ * @throws {Error} if chunk size is less than 1 or not an integer
  * @example
  * chunk([1, 2, 3, 4, 5, 6], 2);
  * // => [[1, 2], [3, 4], [5, 6]]
@@ -26,8 +27,12 @@ function chunk(x/*:Array<any>*/, chunkSize/*:number*/)/*:?Array<Array<any>>*/ {
     // in which we call `start += chunkSize`, will loop infinitely.
     // So, we'll detect and throw in that case to indicate
     // invalid input.
-    if (chunkSize <= 0) {
-        throw new Error('chunk size must be a positive integer');
+    if (chunkSize < 1) {
+        throw new Error('chunk size must be a positive number');
+    }
+
+    if (Math.floor(chunkSize) !== chunkSize) {
+        throw new Error('chunk size must be an integer');
     }
 
     // `start` is the index at which `.slice` will start selecting

--- a/src/ckmeans.js
+++ b/src/ckmeans.js
@@ -216,7 +216,7 @@ function fillMatrices(data, matrix, backtrackMatrix) {
 function ckmeans(data/*: Array<number> */, nClusters/*: number */)/*: Array<Array<number>> */ {
 
     if (nClusters > data.length) {
-        throw new Error('Cannot generate more classes than there are data values');
+        throw new Error('cannot generate more classes than there are data values');
     }
 
     var sorted = numericSort(data),

--- a/src/ckmeans.js
+++ b/src/ckmeans.js
@@ -204,22 +204,23 @@ function fillMatrices(data, matrix, backtrackMatrix) {
  * Programming_ Haizhou Wang and Mingzhou Song ISSN 2073-4859
  *
  * from The R Journal Vol. 3/2, December 2011
- * @param {Array<number>} data input data, as an array of number values
+ * @param {Array<number>} x input data, as an array of number values
  * @param {number} nClusters number of desired classes. This cannot be
  * greater than the number of values in the data array.
  * @returns {Array<Array<number>>} clustered input
+ * @throws {Error} if the number of requested clusters is higher than the size of the data
  * @example
  * ckmeans([-1, 2, -1, 2, 4, 5, 6, -1, 2, -1], 3);
  * // The input, clustered into groups of similar numbers.
  * //= [[-1, -1, -1, -1], [2, 2, 2], [4, 5, 6]]);
  */
-function ckmeans(data/*: Array<number> */, nClusters/*: number */)/*: Array<Array<number>> */ {
+function ckmeans(x/*: Array<number> */, nClusters/*: number */)/*: Array<Array<number>> */ {
 
-    if (nClusters > data.length) {
+    if (nClusters > x.length) {
         throw new Error('cannot generate more classes than there are data values');
     }
 
-    var sorted = numericSort(data),
+    var sorted = numericSort(x),
         // we'll use this as the maximum number of clusters
         uniqueCount = uniqueCountSorted(sorted);
 

--- a/src/combinations.js
+++ b/src/combinations.js
@@ -2,30 +2,30 @@
 'use strict';
 /**
  * Implementation of Combinations
- * Combinations are unique subsets of a collection - in this case, k elements from a collection at a time.
+ * Combinations are unique subsets of a collection - in this case, k x from a collection at a time.
  * https://en.wikipedia.org/wiki/Combination
- * @param {Array} elements any type of data
+ * @param {Array} x any type of data
  * @param {int} k the number of objects in each group (without replacement)
  * @returns {Array<Array>} array of permutations
  * @example
  * combinations([1, 2, 3], 2); // => [[1,2], [1,3], [2,3]]
  */
 
-function combinations(elements /*: Array<any> */, k/*: number */) {
+function combinations(x /*: Array<any> */, k/*: number */) {
     var i;
     var subI;
     var combinationList = [];
     var subsetCombinations;
     var next;
 
-    for (i = 0; i < elements.length; i++) {
+    for (i = 0; i < x.length; i++) {
         if (k === 1) {
-            combinationList.push([elements[i]])
+            combinationList.push([x[i]])
         } else {
-            subsetCombinations = combinations(elements.slice( i + 1, elements.length ), k - 1);
+            subsetCombinations = combinations(x.slice( i + 1, x.length ), k - 1);
             for (subI = 0; subI < subsetCombinations.length; subI++) {
                 next = subsetCombinations[subI];
-                next.unshift(elements[i]);
+                next.unshift(x[i]);
                 combinationList.push(next);
             }
         }

--- a/src/combinations_replacement.js
+++ b/src/combinations_replacement.js
@@ -3,41 +3,41 @@
 
 /**
  * Implementation of [Combinations](https://en.wikipedia.org/wiki/Combination) with replacement
- * Combinations are unique subsets of a collection - in this case, k elements from a collection at a time.
+ * Combinations are unique subsets of a collection - in this case, k x from a collection at a time.
  * 'With replacement' means that a given element can be chosen multiple times.
  * Unlike permutation, order doesn't matter for combinations.
  * 
- * @param {Array} elements any type of data
+ * @param {Array} x any type of data
  * @param {int} k the number of objects in each group (without replacement)
  * @returns {Array<Array>} array of permutations
  * @example
  * combinationsReplacement([1, 2], 2); // => [[1, 1], [1, 2], [2, 2]]
  */
 function combinationsReplacement(
-    elements /*: Array<any> */,
+    x /*: Array<any> */,
     k /*: number */) {
 
     var combinationList = [];
 
-    for (var i = 0; i < elements.length; i++) {
+    for (var i = 0; i < x.length; i++) {
         if (k === 1) {
             // If we're requested to find only one element, we don't need
-            // to recurse: just push `elements[i]` onto the list of combinations.
-            combinationList.push([elements[i]])
+            // to recurse: just push `x[i]` onto the list of combinations.
+            combinationList.push([x[i]])
         } else {
             // Otherwise, recursively find combinations, given `k - 1`. Note that
             // we request `k - 1`, so if you were looking for k=3 combinations, we're
             // requesting k=2. This -1 gets reversed in the for loop right after this
-            // code, since we concatenate `elements[i]` onto the selected combinations,
+            // code, since we concatenate `x[i]` onto the selected combinations,
             // bringing `k` back up to your requested level.
             // This recursion may go many levels deep, since it only stops once
             // k=1.
             var subsetCombinations = combinationsReplacement(
-                elements.slice(i, elements.length),
+                x.slice(i, x.length),
                 k - 1);
 
             for (var j = 0; j < subsetCombinations.length; j++) {
-                combinationList.push([elements[i]]
+                combinationList.push([x[i]]
                     .concat(subsetCombinations[j]));
             }
         }

--- a/src/equal_interval_breaks.js
+++ b/src/equal_interval_breaks.js
@@ -5,32 +5,32 @@ var max = require('./max'),
     min = require('./min');
 
 /**
- * Given an array of data, this will find the extent of the
- * data and return an array of breaks that can be used
- * to categorize the data into a number of classes. The
+ * Given an array of x, this will find the extent of the
+ * x and return an array of breaks that can be used
+ * to categorize the x into a number of classes. The
  * returned array will always be 1 longer than the number of
  * classes because it includes the minimum value.
  *
- * @param {Array<number>} data input data, as an array of number values
+ * @param {Array<number>} x an array of number values
  * @param {number} nClasses number of desired classes
  * @returns {Array<number>} array of class break positions
  * @example
  * equalIntervalBreaks([1, 2, 3, 4, 5, 6], 4); //= [1, 2.25, 3.5, 4.75, 6]
  */
-function equalIntervalBreaks(data/*: Array<number> */, nClasses/*:number*/)/*: Array<number> */ {
+function equalIntervalBreaks(x/*: Array<number> */, nClasses/*:number*/)/*: Array<number> */ {
 
-    if (data.length <= 1) {
-        return data;
+    if (x.length <= 1) {
+        return x;
     }
 
-    var theMin = min(data),
-        theMax = max(data); 
+    var theMin = min(x),
+        theMax = max(x); 
 
     // the first break will always be the minimum value
-    // in the dataset
+    // in the xset
     var breaks = [theMin];
 
-    // The size of each break is the full range of the data
+    // The size of each break is the full range of the x
     // divided by the number of classes requested
     var breakSize = (theMax - theMin) / nClasses;
 

--- a/src/equal_interval_breaks.js
+++ b/src/equal_interval_breaks.js
@@ -19,7 +19,7 @@ var max = require('./max'),
  */
 function equalIntervalBreaks(x/*: Array<number> */, nClasses/*:number*/)/*: Array<number> */ {
 
-    if (x.length <= 1) {
+    if (x.length < 2) {
         return x;
     }
 

--- a/src/factorial.js
+++ b/src/factorial.js
@@ -9,14 +9,19 @@
  *
  * @param {number} n input, must be an integer number 1 or greater
  * @returns {number} factorial: n!
+ * @throws {Error} if n is less than 0 or not an integer
  * @example
  * factorial(5); // => 120
  */
 function factorial(n /*: number */)/*: number */ {
 
     // factorial is mathematically undefined for negative numbers
-    if (n < 0 || Math.floor(n) !== n) {
-        throw new Error('factorial requires an integer value one or greater');
+    if (n < 0) {
+        throw new Error('factorial requires an integer input');
+    }
+
+    if (Math.floor(n) !== n) {
+        throw new Error('factorial requires a non-negative value');
     }
 
     // typically you'll expand the factorial function going down, like

--- a/src/factorial.js
+++ b/src/factorial.js
@@ -7,7 +7,7 @@
  * recursively, but this iterative approach is significantly faster
  * and simpler.
  *
- * @param {number} n input
+ * @param {number} n input, must be an integer number 1 or greater
  * @returns {number} factorial: n!
  * @example
  * factorial(5); // => 120
@@ -15,7 +15,9 @@
 function factorial(n /*: number */)/*: number */ {
 
     // factorial is mathematically undefined for negative numbers
-    if (n < 0) { return NaN; }
+    if (n < 0 || Math.floor(n) !== n) {
+        throw new Error('factorial requires an integer value 1 or greater');
+    }
 
     // typically you'll expand the factorial function going down, like
     // 5! = 5 * 4 * 3 * 2 * 1. This is going in the opposite direction,

--- a/src/factorial.js
+++ b/src/factorial.js
@@ -16,7 +16,7 @@ function factorial(n /*: number */)/*: number */ {
 
     // factorial is mathematically undefined for negative numbers
     if (n < 0 || Math.floor(n) !== n) {
-        throw new Error('factorial requires an integer value 1 or greater');
+        throw new Error('factorial requires an integer value one or greater');
     }
 
     // typically you'll expand the factorial function going down, like

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -17,7 +17,7 @@
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x input array
+ * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} geometric mean
  * @example
  * var growthRates = [1.80, 1.166666, 1.428571];
@@ -35,14 +35,18 @@
  */
 function geometricMean(x /*: Array<number> */) {
     // The mean of no numbers is null
-    if (x.length === 0) { return undefined; }
+    if (x.length === 0) {
+        throw new Error('geometricMean requires at least one data point');
+    }
 
     // the starting value.
     var value = 1;
 
     for (var i = 0; i < x.length; i++) {
         // the geometric mean is only valid for positive numbers
-        if (x[i] <= 0) { return undefined; }
+        if (x[i] <= 0) {
+            throw new Error('geometricMean requires only positive numbers as input');
+        }
 
         // repeatedly multiply the value by each number
         value *= x[i];

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -17,7 +17,7 @@
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
  * @returns {number} geometric mean
  * @throws {Error} if x is empty
  * @throws {Error} if x contains a negative number

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -19,6 +19,8 @@
  *
  * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} geometric mean
+ * @throws {Error} if x is empty
+ * @throws {Error} if x contains a negative number
  * @example
  * var growthRates = [1.80, 1.166666, 1.428571];
  * var averageGrowth = geometricMean(growthRates);

--- a/src/harmonic_mean.js
+++ b/src/harmonic_mean.js
@@ -12,20 +12,24 @@
  *
  * This runs on `O(n)`, linear time in respect to the array.
  *
- * @param {Array<number>} x input
+ * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} harmonic mean
  * @example
  * harmonicMean([2, 3]).toFixed(2) // => '2.40'
  */
 function harmonicMean(x /*: Array<number> */) {
     // The mean of no numbers is null
-    if (x.length === 0) { return undefined; }
+    if (x.length === 0) {
+        throw new Error('harmonicMean requires at least one data point');
+    }
 
     var reciprocalSum = 0;
 
     for (var i = 0; i < x.length; i++) {
         // the harmonic mean is only valid for positive numbers
-        if (x[i] <= 0) { return undefined; }
+        if (x[i] <= 0) {
+            throw new Error('harmonicMean requires only positive numbers as input');
+        }
 
         reciprocalSum += 1 / x[i];
     }

--- a/src/harmonic_mean.js
+++ b/src/harmonic_mean.js
@@ -14,6 +14,8 @@
  *
  * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} harmonic mean
+ * @throws {Error} if x is empty
+ * @throws {Error} if x contains a negative number
  * @example
  * harmonicMean([2, 3]).toFixed(2) // => '2.40'
  */

--- a/src/harmonic_mean.js
+++ b/src/harmonic_mean.js
@@ -12,7 +12,7 @@
  *
  * This runs on `O(n)`, linear time in respect to the array.
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
  * @returns {number} harmonic mean
  * @throws {Error} if x is empty
  * @throws {Error} if x contains a negative number

--- a/src/interquartile_range.js
+++ b/src/interquartile_range.js
@@ -9,17 +9,17 @@ var quantile = require('./quantile');
  * concentrated a distribution is. It's computed as the difference between
  * the third quartile and first quartile.
  *
- * @param {Array<number>} sample
+ * @param {Array<number>} x sample of 1 or more numbers
  * @returns {number} interquartile range: the span between lower and upper quartile,
  * 0.25 and 0.75
  * @example
  * interquartileRange([0, 1, 2, 3]); // => 2
  */
-function interquartileRange(sample/*: Array<number> */) {
+function interquartileRange(x/*: Array<number> */) {
     // Interquartile range is the span between the upper quartile,
     // at `0.75`, and lower quartile, `0.25`
-    var q1 = quantile(sample, 0.75),
-        q2 = quantile(sample, 0.25);
+    var q1 = quantile(x, 0.75),
+        q2 = quantile(x, 0.25);
 
     if (typeof q1 === 'number' && typeof q2 === 'number') {
         return q1 - q2;

--- a/src/interquartile_range.js
+++ b/src/interquartile_range.js
@@ -9,7 +9,7 @@ var quantile = require('./quantile');
  * concentrated a distribution is. It's computed as the difference between
  * the third quartile and first quartile.
  *
- * @param {Array<number>} x sample of 1 or more numbers
+ * @param {Array<number>} x sample of one or more numbers
  * @returns {number} interquartile range: the span between lower and upper quartile,
  * 0.25 and 0.75
  * @example

--- a/src/max.js
+++ b/src/max.js
@@ -6,8 +6,9 @@
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
  * @returns {number} maximum value
+ * @throws {Error} if the the length of x is less than one
  * @example
  * max([1, 2, 3, 4]);
  * // => 4

--- a/src/max.js
+++ b/src/max.js
@@ -6,7 +6,7 @@
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x input
+ * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} maximum value
  * @example
  * max([1, 2, 3, 4]);
@@ -22,7 +22,7 @@ function max(x /*: Array<number> */) /*:number*/ {
         }
     }
     if (value === undefined) {
-        return NaN;
+        throw new Error('max requires at least one data point');
     }
     return value;
 }

--- a/src/mean.js
+++ b/src/mean.js
@@ -11,14 +11,16 @@ var sum = require('./sum');
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x input values
+ * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} mean
  * @example
  * mean([0, 10]); // => 5
  */
 function mean(x /*: Array<number> */)/*:number*/ {
     // The mean of no numbers is null
-    if (x.length === 0) { return NaN; }
+    if (x.length === 0) {
+        throw new Error('mean requires at least one data point');
+    }
 
     return sum(x) / x.length;
 }

--- a/src/mean.js
+++ b/src/mean.js
@@ -11,7 +11,8 @@ var sum = require('./sum');
  *
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
+ * @throws {Error} if the the length of x is less than one
  * @returns {number} mean
  * @example
  * mean([0, 10]); // => 5

--- a/src/min.js
+++ b/src/min.js
@@ -4,7 +4,7 @@
 /**
  * The min is the lowest number in the array. This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x input
+ * @param {Array<number>} x sample of 1 or more data points
  * @returns {number} minimum value
  * @example
  * min([1, 5, -10, 100, 2]); // => -10
@@ -19,7 +19,7 @@ function min(x /*: Array<number> */)/*:number*/ {
         }
     }
     if (value === undefined) {
-        return NaN;
+        throw new Error('min requires at least one data point');
     }
     return value;
 }

--- a/src/min.js
+++ b/src/min.js
@@ -4,7 +4,8 @@
 /**
  * The min is the lowest number in the array. This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
+ * @throws {Error} if the the length of x is less than one
  * @returns {number} minimum value
  * @example
  * min([1, 5, -10, 100, 2]); // => -10

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -11,6 +11,7 @@
  * @param {Array} [array=] a single array instance which will be augmented
  * with the extra methods. If omitted, mixin will apply to all arrays
  * by changing the global `Array.prototype`.
+ * @throws {Error} if the JavaScript environment doesn't support Object.defineProperty
  * @returns {*} the extended Array, or Array.prototype if no object
  * is given.
  *

--- a/src/mode_fast.js
+++ b/src/mode_fast.js
@@ -20,6 +20,7 @@
  * @param {Array<*>} x a sample of one or more data points
  * @returns {?*} mode
  * @throws {ReferenceError} if the JavaScript environment doesn't support Map
+ * @throws {Error} if x is empty
  * @example
  * modeFast(['rabbits', 'rabbits', 'squirrels']); // => 'rabbits'
  */

--- a/src/mode_fast.js
+++ b/src/mode_fast.js
@@ -17,7 +17,7 @@
  * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
  * a method of finding a typical or central value of a set of numbers.
  *
- * @param {Array<*>} x input
+ * @param {Array<*>} x a sample of one or more data points
  * @returns {?*} mode
  * @throws {ReferenceError} if the JavaScript environment doesn't support Map
  * @example
@@ -46,6 +46,10 @@ function modeFast/*::<T>*/(x /*: Array<T> */)/*: ?T */ {
             modeCount = newCount;
         }
         index.set(x[i], newCount);
+    }
+
+    if (modeCount === 0) {
+        throw new Error('mode requires at last one data point');
     }
 
     return mode;

--- a/src/mode_sorted.js
+++ b/src/mode_sorted.js
@@ -11,7 +11,7 @@
  *
  * This runs in `O(n)` because the input is sorted.
  *
- * @param {Array<number>} sorted input
+ * @param {Array<number>} sorted a sample of 1 or more data points
  * @returns {number} mode
  * @example
  * modeSorted([0, 0, 1]); // => 0
@@ -19,9 +19,12 @@
 function modeSorted(sorted /*: Array<number> */)/*:number*/ {
 
     // Handle edge cases:
-    // The mode of an empty list is NaN
-    if (sorted.length === 0) { return NaN; }
-    else if (sorted.length === 1) { return sorted[0]; }
+    // The mode of an empty list is undefined
+    if (sorted.length === 0) {
+        throw new Error('mode requires at least one data point');
+    } else if (sorted.length === 1) {
+        return sorted[0];
+    }
 
     // This assumes it is dealing with an array of size > 1, since size
     // 0 and 1 are handled immediately. Hence it starts at index 1 in the

--- a/src/mode_sorted.js
+++ b/src/mode_sorted.js
@@ -11,7 +11,7 @@
  *
  * This runs in `O(n)` because the input is sorted.
  *
- * @param {Array<number>} sorted a sample of 1 or more data points
+ * @param {Array<number>} sorted a sample of one or more data points
  * @returns {number} mode
  * @throws {Error} if sorted is empty
  * @example

--- a/src/mode_sorted.js
+++ b/src/mode_sorted.js
@@ -13,6 +13,7 @@
  *
  * @param {Array<number>} sorted a sample of 1 or more data points
  * @returns {number} mode
+ * @throws {Error} if sorted is empty
  * @example
  * modeSorted([0, 0, 1]); // => 0
  */

--- a/src/numeric_sort.js
+++ b/src/numeric_sort.js
@@ -12,14 +12,14 @@
  *     // output
  *     [1, 10, 102, 12, 20]
  *
- * @param {Array<number>} array input array
+ * @param {Array<number>} x input array
  * @return {Array<number>} sorted array
  * @private
  * @example
  * numericSort([3, 2, 1]) // => [1, 2, 3]
  */
-function numericSort(array /*: Array<number> */) /*: Array<number> */ {
-    return array
+function numericSort(x /*: Array<number> */) /*: Array<number> */ {
+    return x
         // ensure the array is not changed in-place
         .slice()
         // comparator function that treats input as numeric

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -19,14 +19,14 @@ var quickselect = require('./quickselect');
  * When p is an array, the result of the function is also an array containing the appropriate
  * quantiles in input order
  *
- * @param {Array<number>} sample a sample from the population
+ * @param {Array<number>} x sample of 1 or more numbers
  * @param {number} p the desired quantile, as a number between 0 and 1
  * @returns {number} quantile
  * @example
  * quantile([3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20], 0.5); // => 9
  */
-function quantile(sample /*: Array<number> */, p /*: Array<number> | number */) {
-    var copy = sample.slice();
+function quantile(x /*: Array<number> */, p /*: Array<number> | number */) {
+    var copy = x.slice();
 
     if (Array.isArray(p)) {
         // rearrange elements so that each element corresponding to a requested

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -19,7 +19,7 @@ var quickselect = require('./quickselect');
  * When p is an array, the result of the function is also an array containing the appropriate
  * quantiles in input order
  *
- * @param {Array<number>} x sample of 1 or more numbers
+ * @param {Array<number>} x sample of one or more numbers
  * @param {number} p the desired quantile, as a number between 0 and 1
  * @returns {number} quantile
  * @example

--- a/src/quantile_sorted.js
+++ b/src/quantile_sorted.js
@@ -6,7 +6,7 @@
  * that the order is sorted, you don't need to re-sort it, and the computations
  * are faster.
  *
- * @param {Array<number>} x sample of 1 or more data points
+ * @param {Array<number>} x sample of one or more data points
  * @param {number} p desired quantile: a number between 0 to 1, inclusive
  * @returns {number} quantile value
  * @throws {Error} if p ix outside of the range from 0 to 1

--- a/src/quantile_sorted.js
+++ b/src/quantile_sorted.js
@@ -9,6 +9,8 @@
  * @param {Array<number>} x sample of 1 or more data points
  * @param {number} p desired quantile: a number between 0 to 1, inclusive
  * @returns {number} quantile value
+ * @throws {Error} if p ix outside of the range from 0 to 1
+ * @throws {Error} if x is empty
  * @example
  * quantileSorted([3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20], 0.5); // => 9
  */

--- a/src/quantile_sorted.js
+++ b/src/quantile_sorted.js
@@ -6,33 +6,35 @@
  * that the order is sorted, you don't need to re-sort it, and the computations
  * are faster.
  *
- * @param {Array<number>} sample input data
+ * @param {Array<number>} x sample of 1 or more data points
  * @param {number} p desired quantile: a number between 0 to 1, inclusive
  * @returns {number} quantile value
  * @example
  * quantileSorted([3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20], 0.5); // => 9
  */
-function quantileSorted(sample /*: Array<number> */, p /*: number */)/*:number*/ {
-    var idx = sample.length * p;
-    if (p < 0 || p > 1) {
-        return NaN;
+function quantileSorted(x /*: Array<number> */, p /*: number */)/*:number*/ {
+    var idx = x.length * p;
+    if (x.length === 0) {
+        throw new Error('quantile requires at least one data point.');
+    } else if (p < 0 || p > 1) {
+        throw new Error('quantiles must be between 0 and 1');
     } else if (p === 1) {
         // If p is 1, directly return the last element
-        return sample[sample.length - 1];
+        return x[x.length - 1];
     } else if (p === 0) {
         // If p is 0, directly return the first element
-        return sample[0];
+        return x[0];
     } else if (idx % 1 !== 0) {
         // If p is not integer, return the next element in array
-        return sample[Math.ceil(idx) - 1];
-    } else if (sample.length % 2 === 0) {
+        return x[Math.ceil(idx) - 1];
+    } else if (x.length % 2 === 0) {
         // If the list has even-length, we'll take the average of this number
         // and the next value, if there is one
-        return (sample[idx - 1] + sample[idx]) / 2;
+        return (x[idx - 1] + x[idx]) / 2;
     } else {
         // Finally, in the simple case of an integer value
-        // with an odd-length list, return the sample value at the index.
-        return sample[idx];
+        // with an odd-length list, return the x value at the index.
+        return x[idx];
     }
 }
 

--- a/src/r_squared.js
+++ b/src/r_squared.js
@@ -7,7 +7,7 @@
  * is the sum of the squared differences between the prediction
  * and the actual value.
  *
- * @param {Array<Array<number>>} data input data: this should be doubly-nested
+ * @param {Array<Array<number>>} x input data: this should be doubly-nested
  * @param {Function} func function called on `[i][0]` values within the dataset
  * @returns {number} r-squared value
  * @example
@@ -15,32 +15,32 @@
  * var regressionLine = linearRegressionLine(linearRegression(samples));
  * rSquared(samples, regressionLine); // = 1 this line is a perfect fit
  */
-function rSquared(data /*: Array<Array<number>> */, func /*: Function */) /*: number */ {
-    if (data.length < 2) { return 1; }
+function rSquared(x /*: Array<Array<number>> */, func /*: Function */) /*: number */ {
+    if (x.length < 2) { return 1; }
 
     // Compute the average y value for the actual
     // data set in order to compute the
     // _total sum of squares_
     var sum = 0, average;
-    for (var i = 0; i < data.length; i++) {
-        sum += data[i][1];
+    for (var i = 0; i < x.length; i++) {
+        sum += x[i][1];
     }
-    average = sum / data.length;
+    average = sum / x.length;
 
     // Compute the total sum of squares - the
     // squared difference between each point
     // and the average of all points.
     var sumOfSquares = 0;
-    for (var j = 0; j < data.length; j++) {
-        sumOfSquares += Math.pow(average - data[j][1], 2);
+    for (var j = 0; j < x.length; j++) {
+        sumOfSquares += Math.pow(average - x[j][1], 2);
     }
 
     // Finally estimate the error: the squared
     // difference between the estimate and the actual data
     // value at each point.
     var err = 0;
-    for (var k = 0; k < data.length; k++) {
-        err += Math.pow(data[k][1] - func(data[k][0]), 2);
+    for (var k = 0; k < x.length; k++) {
+        err += Math.pow(x[k][1] - func(x[k][0]), 2);
     }
 
     // As the error grows larger, its ratio to the

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -9,13 +9,15 @@
  * input numbers.
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x input
+ * @param {Array<number>} x a sample of 1 or more data points
  * @returns {number} root mean square
  * @example
  * rootMeanSquare([-1, 1, -1, 1]); // => 1
  */
 function rootMeanSquare(x /*: Array<number> */)/*:number*/ {
-    if (x.length === 0) { return NaN; }
+    if (x.length === 0) {
+        throw new Error('rootMeanSquare requires at least one data point');
+    }
 
     var sumOfSquares = 0;
     for (var i = 0; i < x.length; i++) {

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -11,6 +11,7 @@
  *
  * @param {Array<number>} x a sample of 1 or more data points
  * @returns {number} root mean square
+ * @throws {Error} if x is empty
  * @example
  * rootMeanSquare([-1, 1, -1, 1]); // => 1
  */

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -9,7 +9,7 @@
  * input numbers.
  * This runs on `O(n)`, linear time in respect to the array
  *
- * @param {Array<number>} x a sample of 1 or more data points
+ * @param {Array<number>} x a sample of one or more data points
  * @returns {number} root mean square
  * @throws {Error} if x is empty
  * @example

--- a/src/sample.js
+++ b/src/sample.js
@@ -10,7 +10,7 @@ var shuffle = require('./shuffle');
  * The sampled values will be in any order, not necessarily the order
  * they appear in the input.
  *
- * @param {Array} array input array. can contain any type
+ * @param {Array<any>} x input array. can contain any type
  * @param {number} n count of how many elements to take
  * @param {Function} [randomSource=Math.random] an optional entropy source that
  * returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
@@ -20,11 +20,11 @@ var shuffle = require('./shuffle');
  * sample(values, 3); // returns 3 random values, like [2, 5, 8];
  */
 function sample/*:: <T> */(
-    array /*: Array<T> */,
+    x /*: Array<T> */,
     n /*: number */,
     randomSource /*: Function */) /*: Array<T> */ {
     // shuffle the original array using a fisher-yates shuffle
-    var shuffled = shuffle(array, randomSource);
+    var shuffled = shuffle(x, randomSource);
 
     // and then return a subset of it - the first `n` elements.
     return shuffled.slice(0, n);

--- a/src/sample_covariance.js
+++ b/src/sample_covariance.js
@@ -8,8 +8,10 @@ var mean = require('./mean');
  * how much do the two datasets move together?
  * x and y are two datasets, represented as arrays of numbers.
  *
- * @param {Array<number>} x a sample of 1 or more data points
- * @param {Array<number>} y a sample of 1 or more data points
+ * @param {Array<number>} x a sample of two or more data points
+ * @param {Array<number>} y a sample of two or more data points
+ * @throws {Error} if x and y do not have equal lengths
+ * @throws {Error} if x or y have length of one or less
  * @returns {number} sample covariance
  * @example
  * sampleCovariance([1, 2, 3, 4, 5, 6], [6, 5, 4, 3, 2, 1]); // => -3.5
@@ -21,8 +23,8 @@ function sampleCovariance(x /*:Array<number>*/, y /*:Array<number>*/)/*:number*/
         throw new Error('sampleCovariance requires samples with equal lengths');
     }
 
-    if (x.length <= 1) {
-        throw new Error('sampleCovariance requires at least one data point in each sample');
+    if (x.length < 2) {
+        throw new Error('sampleCovariance requires at least two data points in each sample');
     }
 
     // determine the mean of each dataset so that we can judge each

--- a/src/sample_covariance.js
+++ b/src/sample_covariance.js
@@ -8,8 +8,8 @@ var mean = require('./mean');
  * how much do the two datasets move together?
  * x and y are two datasets, represented as arrays of numbers.
  *
- * @param {Array<number>} x first input
- * @param {Array<number>} y second input
+ * @param {Array<number>} x a sample of 1 or more data points
+ * @param {Array<number>} y a sample of 1 or more data points
  * @returns {number} sample covariance
  * @example
  * sampleCovariance([1, 2, 3, 4, 5, 6], [6, 5, 4, 3, 2, 1]); // => -3.5
@@ -17,8 +17,12 @@ var mean = require('./mean');
 function sampleCovariance(x /*:Array<number>*/, y /*:Array<number>*/)/*:number*/ {
 
     // The two datasets must have the same length which must be more than 1
-    if (x.length <= 1 || x.length !== y.length) {
-        return NaN;
+    if (x.length !== y.length) {
+        throw new Error('sampleCovariance requires datasets with equal lengths');
+    }
+
+    if (x.length <= 1) {
+        throw new Error('sampleCovariance requires datasets with at least one data point');
     }
 
     // determine the mean of each dataset so that we can judge each

--- a/src/sample_covariance.js
+++ b/src/sample_covariance.js
@@ -18,11 +18,11 @@ function sampleCovariance(x /*:Array<number>*/, y /*:Array<number>*/)/*:number*/
 
     // The two datasets must have the same length which must be more than 1
     if (x.length !== y.length) {
-        throw new Error('sampleCovariance requires datasets with equal lengths');
+        throw new Error('sampleCovariance requires samples with equal lengths');
     }
 
     if (x.length <= 1) {
-        throw new Error('sampleCovariance requires datasets with at least one data point');
+        throw new Error('sampleCovariance requires at least one data point in each sample');
     }
 
     // determine the mean of each dataset so that we can judge each

--- a/src/sample_skewness.js
+++ b/src/sample_skewness.js
@@ -16,6 +16,7 @@ var sampleStandardDeviation = require('./sample_standard_deviation');
  *
  * @param {Array<number>} x a sample of 3 or more data points
  * @returns {number} sample skewness
+ * @throws {Error} if x has length of 3 or less
  * @example
  * sampleSkewness([2, 4, 6, 3, 1]); // => 0.590128656384365
  */

--- a/src/sample_skewness.js
+++ b/src/sample_skewness.js
@@ -14,7 +14,7 @@ var sampleStandardDeviation = require('./sample_standard_deviation');
  * moment coefficient, which is the version found in Excel and several
  * statistical packages including Minitab, SAS and SPSS.
  *
- * @param {Array<number>} x input
+ * @param {Array<number>} x a sample of 3 or more data points
  * @returns {number} sample skewness
  * @example
  * sampleSkewness([2, 4, 6, 3, 1]); // => 0.590128656384365
@@ -23,8 +23,8 @@ function sampleSkewness(x /*: Array<number> */)/*:number*/ {
     // The skewness of less than three arguments is null
     var theSampleStandardDeviation = sampleStandardDeviation(x);
 
-    if (isNaN(theSampleStandardDeviation) || x.length < 3) {
-        return NaN;
+    if (x.length < 3) {
+        throw new Error('sampleSkewness requires at least three data points');
     }
 
     var n = x.length,

--- a/src/sample_standard_deviation.js
+++ b/src/sample_standard_deviation.js
@@ -16,7 +16,6 @@ var sampleVariance = require('./sample_variance');
 function sampleStandardDeviation(x/*:Array<number>*/)/*:number*/ {
     // The standard deviation of no numbers is null
     var sampleVarianceX = sampleVariance(x);
-    if (isNaN(sampleVarianceX)) { return NaN; }
     return Math.sqrt(sampleVarianceX);
 }
 

--- a/src/sample_variance.js
+++ b/src/sample_variance.js
@@ -14,7 +14,7 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * References:
  * * [Wolfram MathWorld on Sample Variance](http://mathworld.wolfram.com/SampleVariance.html)
  *
- * @param {Array<number>} x a sample of 2 or more data points
+ * @param {Array<number>} x a sample of two or more data points
  * @throws {Error} if the length of x is less than 2
  * @return {number} sample variance
  * @example
@@ -23,7 +23,7 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
 function sampleVariance(x /*: Array<number> */)/*:number*/ {
     // The variance of no numbers is null
     if (x.length < 2) {
-        throw new Error('sampleCorrelation requires at least two data points');
+        throw new Error('sampleVariance requires at least two data points');
     }
 
     var sumSquaredDeviationsValue = sumNthPowerDeviations(x, 2);

--- a/src/sample_variance.js
+++ b/src/sample_variance.js
@@ -14,14 +14,16 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * References:
  * * [Wolfram MathWorld on Sample Variance](http://mathworld.wolfram.com/SampleVariance.html)
  *
- * @param {Array<number>} x input array
+ * @param {Array<number>} x a sample of 2 or more data points
  * @return {number} sample variance
  * @example
  * sampleVariance([1, 2, 3, 4, 5]); // => 2.5
  */
 function sampleVariance(x /*: Array<number> */)/*:number*/ {
     // The variance of no numbers is null
-    if (x.length <= 1) { return NaN; }
+    if (x.length <= 1) {
+        throw new Error('sampleCorrelation requires at least two data points');
+    }
 
     var sumSquaredDeviationsValue = sumNthPowerDeviations(x, 2);
 

--- a/src/sample_variance.js
+++ b/src/sample_variance.js
@@ -15,13 +15,14 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * * [Wolfram MathWorld on Sample Variance](http://mathworld.wolfram.com/SampleVariance.html)
  *
  * @param {Array<number>} x a sample of 2 or more data points
+ * @throws {Error} if the length of x is less than 2
  * @return {number} sample variance
  * @example
  * sampleVariance([1, 2, 3, 4, 5]); // => 2.5
  */
 function sampleVariance(x /*: Array<number> */)/*:number*/ {
     // The variance of no numbers is null
-    if (x.length <= 1) {
+    if (x.length < 2) {
         throw new Error('sampleCorrelation requires at least two data points');
     }
 

--- a/src/sample_with_replacement.js
+++ b/src/sample_with_replacement.js
@@ -5,7 +5,7 @@
  * Sampling with replacement is a type of sampling that allows the same
  * item to be picked out of a population more than once.
  *
- * @param {Array} population an array of any kind of element
+ * @param {Array<*>} x an array of any kind of value
  * @param {number} n count of how many elements to take
  * @param {Function} [randomSource=Math.random] an optional entropy source that
  * returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
@@ -14,11 +14,11 @@
  * var sample = sampleWithReplacement([1, 2, 3, 4], 2);
  * sampleWithReplacement; // = [2, 4] or any other random sample of 2 items
  */
-function sampleWithReplacement/*::<T>*/(population/*:Array<T>*/,
+function sampleWithReplacement/*::<T>*/(x/*:Array<T>*/,
     n /*: number */,
     randomSource/*:Function*/) {
 
-    if (population.length === 0) {
+    if (x.length === 0) {
         return [];
     }
 
@@ -27,13 +27,13 @@ function sampleWithReplacement/*::<T>*/(population/*:Array<T>*/,
     // [random-js](https://www.npmjs.org/package/random-js)
     randomSource = randomSource || Math.random;
 
-    var length = population.length;
+    var length = x.length;
     var sample = [];
 
     for (var i = 0; i < n; i++) {
         var index = Math.floor(randomSource() * length);
 
-        sample.push(population[index]);
+        sample.push(x[index]);
     }
 
     return sample;

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -9,7 +9,7 @@ var shuffleInPlace = require('./shuffle_in_place');
  * a function around `shuffle_in_place` that adds the guarantee that
  * it will not modify its input.
  *
- * @param {Array} sample an array of any kind of element
+ * @param {Array} x sample of 0 or more numbers
  * @param {Function} [randomSource=Math.random] an optional entropy source that
  * returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
  * @return {Array} shuffled version of input
@@ -17,9 +17,9 @@ var shuffleInPlace = require('./shuffle_in_place');
  * var shuffled = shuffle([1, 2, 3, 4]);
  * shuffled; // = [2, 3, 1, 4] or any other random permutation
  */
-function shuffle/*::<T>*/(sample/*:Array<T>*/, randomSource/*:Function*/) {
+function shuffle/*::<T>*/(x/*:Array<T>*/, randomSource/*:Function*/) {
     // slice the original array so that it is not modified
-    sample = sample.slice();
+    var sample = x.slice();
 
     // and then shuffle that shallow-copied array, in place
     return shuffleInPlace(sample.slice(), randomSource);

--- a/src/shuffle_in_place.js
+++ b/src/shuffle_in_place.js
@@ -9,26 +9,25 @@
  * This is an algorithm that generates a random [permutation](https://en.wikipedia.org/wiki/Permutation)
  * of a set.
  *
- * @param {Array} sample input array
+ * @param {Array} x x of 1 or more numbers
  * @param {Function} [randomSource=Math.random] an optional entropy source that
  * returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
- * @returns {Array} sample
+ * @returns {Array} x
  * @example
- * var sample = [1, 2, 3, 4];
- * shuffleInPlace(sample);
- * // sample is shuffled to a value like [2, 1, 4, 3]
+ * var x = [1, 2, 3, 4];
+ * shuffleInPlace(x);
+ * // x is shuffled to a value like [2, 1, 4, 3]
  */
-function shuffleInPlace(sample/*:Array<any>*/, randomSource/*:Function*/)/*:Array<any>*/ {
-
+function shuffleInPlace(x/*:Array<any>*/, randomSource/*:Function*/)/*:Array<any>*/ {
 
     // a custom random number source can be provided if you want to use
     // a fixed seed or another random number generator, like
     // [random-js](https://www.npmjs.org/package/random-js)
     randomSource = randomSource || Math.random;
 
-    // store the current length of the sample to determine
+    // store the current length of the x to determine
     // when no elements remain to shuffle.
-    var length = sample.length;
+    var length = x.length;
 
     // temporary is used to hold an item when it is being
     // swapped between indices.
@@ -44,14 +43,14 @@ function shuffleInPlace(sample/*:Array<any>*/, randomSource/*:Function*/)/*:Arra
         index = Math.floor(randomSource() * length--);
 
         // store the value that we'll move temporarily
-        temporary = sample[length];
+        temporary = x[length];
 
-        // swap the value at `sample[length]` with `sample[index]`
-        sample[length] = sample[index];
-        sample[index] = temporary;
+        // swap the value at `x[length]` with `x[index]`
+        x[length] = x[index];
+        x[index] = temporary;
     }
 
-    return sample;
+    return x;
 }
 
 module.exports = shuffleInPlace;

--- a/src/shuffle_in_place.js
+++ b/src/shuffle_in_place.js
@@ -9,7 +9,7 @@
  * This is an algorithm that generates a random [permutation](https://en.wikipedia.org/wiki/Permutation)
  * of a set.
  *
- * @param {Array} x x of 1 or more numbers
+ * @param {Array} x sample of one or more numbers
  * @param {Function} [randomSource=Math.random] an optional entropy source that
  * returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
  * @returns {Array} x

--- a/src/standard_deviation.js
+++ b/src/standard_deviation.js
@@ -20,7 +20,7 @@ var variance = require('./variance');
  * standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]); // => 2
  */
 function standardDeviation(x /*: Array<number> */)/*:number*/ {
-    if (x.length === 0) {
+    if (x.length === 1) {
         return 0;
     }
     var v = variance(x);

--- a/src/standard_deviation.js
+++ b/src/standard_deviation.js
@@ -19,9 +19,7 @@ var variance = require('./variance');
  * standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]); // => 2
  */
 function standardDeviation(x /*: Array<number> */)/*:number*/ {
-    // The standard deviation of no numbers is null
     var v = variance(x);
-    if (isNaN(v)) { return 0; }
     return Math.sqrt(v);
 }
 

--- a/src/standard_deviation.js
+++ b/src/standard_deviation.js
@@ -5,7 +5,8 @@ var variance = require('./variance');
 
 /**
  * The [standard deviation](http://en.wikipedia.org/wiki/Standard_deviation)
- * is the square root of the variance. It's useful for measuring the amount
+ * is the square root of the variance. This is also known as the population
+ * standard deviation. It's useful for measuring the amount
  * of variation or dispersion in a set of values.
  *
  * Standard deviation is only appropriate for full-population knowledge: for
@@ -19,6 +20,9 @@ var variance = require('./variance');
  * standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]); // => 2
  */
 function standardDeviation(x /*: Array<number> */)/*:number*/ {
+    if (x.length === 0) {
+        return 0;
+    }
     var v = variance(x);
     return Math.sqrt(v);
 }

--- a/src/t_test.js
+++ b/src/t_test.js
@@ -15,24 +15,24 @@ var mean = require('./mean');
  * a certain level of significance, will let you determine that the
  * null hypothesis can or cannot be rejected.
  *
- * @param {Array<number>} sample an array of numbers as input
- * @param {number} x expected value of the population mean
+ * @param {Array<number>} x sample of 1 or more numbers
+ * @param {number} expectedValue expected value of the population mean
  * @returns {number} value
  * @example
  * tTest([1, 2, 3, 4, 5, 6], 3.385).toFixed(2); // => '0.16'
  */
-function tTest(sample/*: Array<number> */, x/*: number */)/*:number*/ {
+function tTest(x/*: Array<number> */, expectedValue/*: number */)/*:number*/ {
     // The mean of the sample
-    var sampleMean = mean(sample);
+    var sampleMean = mean(x);
 
     // The standard deviation of the sample
-    var sd = standardDeviation(sample);
+    var sd = standardDeviation(x);
 
     // Square root the length of the sample
-    var rootN = Math.sqrt(sample.length);
+    var rootN = Math.sqrt(x.length);
 
     // returning the t value
-    return (sampleMean - x) / (sd / rootN);
+    return (sampleMean - expectedValue) / (sd / rootN);
 }
 
 module.exports = tTest;

--- a/src/t_test.js
+++ b/src/t_test.js
@@ -15,7 +15,7 @@ var mean = require('./mean');
  * a certain level of significance, will let you determine that the
  * null hypothesis can or cannot be rejected.
  *
- * @param {Array<number>} x sample of 1 or more numbers
+ * @param {Array<number>} x sample of one or more numbers
  * @param {number} expectedValue expected value of the population mean
  * @returns {number} value
  * @example

--- a/src/unique_count_sorted.js
+++ b/src/unique_count_sorted.js
@@ -9,18 +9,18 @@
  * Values are compared with `===`, so objects and non-primitive objects
  * are not handled in any special way.
  *
- * @param {Array} input an array of primitive values.
+ * @param {Array<*>} x an array of any kind of value
  * @returns {number} count of unique values
  * @example
  * uniqueCountSorted([1, 2, 3]); // => 3
  * uniqueCountSorted([1, 1, 1]); // => 1
  */
-function uniqueCountSorted(input/*: Array<any>*/)/*: number */ {
+function uniqueCountSorted(x/*: Array<any>*/)/*: number */ {
     var uniqueValueCount = 0,
         lastSeenValue;
-    for (var i = 0; i < input.length; i++) {
-        if (i === 0 || input[i] !== lastSeenValue) {
-            lastSeenValue = input[i];
+    for (var i = 0; i < x.length; i++) {
+        if (i === 0 || x[i] !== lastSeenValue) {
+            lastSeenValue = x[i];
             uniqueValueCount++;
         }
     }

--- a/src/variance.js
+++ b/src/variance.js
@@ -10,7 +10,7 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * This is an implementation of variance, not sample variance:
  * see the `sampleVariance` method if you want a sample measure.
  *
- * @param {Array<number>} x a population of 1 or more data points
+ * @param {Array<number>} x a population of one or more data points
  * @returns {number} variance: a value greater than or equal to zero.
  * zero indicates that all values are identical.
  * @throws {Error} if x's length is 0

--- a/src/variance.js
+++ b/src/variance.js
@@ -13,6 +13,7 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * @param {Array<number>} x a population of 1 or more data points
  * @returns {number} variance: a value greater than or equal to zero.
  * zero indicates that all values are identical.
+ * @throws {Error} if x's length is 0
  * @example
  * variance([1, 2, 3, 4, 5, 6]); // => 2.9166666666666665
  */

--- a/src/variance.js
+++ b/src/variance.js
@@ -10,7 +10,7 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  * This is an implementation of variance, not sample variance:
  * see the `sampleVariance` method if you want a sample measure.
  *
- * @param {Array<number>} x a population
+ * @param {Array<number>} x a population of 1 or more data points
  * @returns {number} variance: a value greater than or equal to zero.
  * zero indicates that all values are identical.
  * @example
@@ -18,7 +18,9 @@ var sumNthPowerDeviations = require('./sum_nth_power_deviations');
  */
 function variance(x/*: Array<number> */)/*:number*/ {
     // The variance of no numbers is null
-    if (x.length === 0) { return NaN; }
+    if (x.length === 0) {
+        throw new Error('variance requires at least one data point');
+    }
 
     // Find the mean of squared deviations between the
     // mean value and each value.

--- a/test/bernoulli_distribution.test.js
+++ b/test/bernoulli_distribution.test.js
@@ -12,8 +12,12 @@ test('bernoulliDistribution', function(t) {
         t.end();
     });
     t.test('can return null when p is not a valid probability', function(t) {
-        t.ok(isNaN(ss.bernoulliDistribution(-0.01)), 'p should be greater than 0.0');
-        t.ok(isNaN(ss.bernoulliDistribution(1.5)), 'p should be less than 1.0');
+        t.throws(function () {
+            ss.bernoulliDistribution(-0.01);
+        }, 'p should be greater than 0.0');
+        t.throws(function() {
+            ss.bernoulliDistribution(1.5);
+        }, 'p should be less than 1.0');
         t.end();
     });
     t.end();

--- a/test/factorial.test.js
+++ b/test/factorial.test.js
@@ -5,8 +5,16 @@ var test = require('tap').test;
 var ss = require('../');
 
 test('factorial', function(t) {
-    t.test('can return NaN given a negative number', function(t) {
-        t.ok(isNaN(ss.factorial(-1)));
+    t.test('cannot calculate the factorial of a number lower than zero', function(t) {
+        t.throws(function() {
+            ss.factorial(-1);
+        });
+        t.end();
+    });
+    t.test('rejects floating-point inputs', function(t) {
+        t.throws(function() {
+            ss.factorial(-1);
+        });
         t.end();
     });
     t.test('can calculate 0! = 1', function(t) {

--- a/test/geometric_mean.test.js
+++ b/test/geometric_mean.test.js
@@ -13,13 +13,17 @@ test('geometric mean', function(t) {
         t.end();
     });
 
-    t.test('returns NaN for empty lists', function(t) {
-        t.ok(isNaN(ss.geometricMean([])));
+    t.test('cannot calculate for empty lists', function(t) {
+        t.throws(function() {
+            ss.geometricMean([]);
+        });
         t.end();
     });
 
-    t.test('returns NaN for lists with negative numbers', function(t) {
-        t.ok(isNaN(ss.geometricMean([-1])));
+    t.test('cannot calculate for lists with negative numbers', function(t) {
+        t.throws(function() {
+            ss.geometricMean([-1]);
+        });
         t.end();
     });
     t.end();

--- a/test/harmonic_mean.test.js
+++ b/test/harmonic_mean.test.js
@@ -17,13 +17,17 @@ test('harmonicMean', function(t) {
         t.end();
     });
 
-    t.test('returns NaN for empty lists', function(t) {
-        t.ok(isNaN(ss.harmonicMean([])));
+    t.test('cannot calculate for empty lists', function(t) {
+        t.throws(function() {
+            ss.harmonicMean([]);
+        });
         t.end();
     });
 
-    t.test('returns NaN for lists with negative numbers', function(t) {
-        t.ok(isNaN(ss.harmonicMean([-1])));
+    t.test('cannot calculate for lists with negative numbers', function(t) {
+        t.throws(function() {
+            ss.harmonicMean([-1]);
+        });
         t.end();
     });
     t.end();

--- a/test/iqr.test.js
+++ b/test/iqr.test.js
@@ -19,8 +19,10 @@ test('interquartile range (iqr)', function(t) {
         t.end();
     });
 
-    t.test('an iqr of a zero-length list produces NaN', function(t) {
-        t.ok(isNaN(ss.iqr([])));
+    t.test('an iqr of a zero-length list cannot be calculated', function(t) {
+        t.throws(function () {
+            ss.iqr([]);
+        });
         t.end();
     });
     t.end();

--- a/test/mad.test.js
+++ b/test/mad.test.js
@@ -22,7 +22,9 @@ test('median absolute deviation (mad)', function(t) {
     });
 
     t.test('zero-length corner case', function(t) {
-        t.ok(isNaN(ss.mad([])));
+        t.throws(function() {
+            ss.mad([]);
+        });
         t.end();
     });
     t.end();

--- a/test/mean.test.js
+++ b/test/mean.test.js
@@ -14,7 +14,9 @@ test('mean', function(t) {
         t.end();
     });
     t.test('an empty list has no average', function(t) {
-        t.ok(isNaN(ss.mean([])));
+        t.throws(function() {
+            ss.mean([]);
+        });
         t.end();
     });
     t.end();

--- a/test/median.test.js
+++ b/test/median.test.js
@@ -21,8 +21,10 @@ test('median', function(t) {
         t.end();
     });
 
-    t.test('gives NaN for the median of an empty list', function(t) {
-        t.ok(isNaN(ss.median([])));
+    t.test('cannot calculate the median of an empty list', function(t) {
+        t.throws(function() {
+            ss.median([]);
+        });
         t.end();
     });
 

--- a/test/minmax.test.js
+++ b/test/minmax.test.js
@@ -5,7 +5,9 @@ var test = require('tap').test;
 var ss = require('../');
 
 test('min', function(t) {
-    t.ok(isNaN(ss.min([])), 'min zero array NaN');
+    t.throws(function() {
+        ss.min([]);
+    }, 'zero length array throws');
     t.test('can get the minimum of one number', function(t) {
         t.equal(ss.min([1]), 1);
         t.end();
@@ -19,7 +21,9 @@ test('min', function(t) {
 });
 
 test('max', function(t) {
-    t.ok(isNaN(ss.max([])), 'max zero array NaN');
+    t.throws(function() {
+        ss.max([]);
+    }, 'zero length array throws');
     t.test('can get the maximum of three numbers', function(t) {
         t.equal(ss.max([1, 7, -1000]), 7);
         t.end();

--- a/test/mode.test.js
+++ b/test/mode.test.js
@@ -34,7 +34,9 @@ test('mode', function(t) {
             });
 
             t.test('the mode of an empty array is null', function(t) {
-                t.ok(isNaN(modeFn([])));
+                t.throws(function() {
+                    modeFn([]);
+                });
                 t.end();
             });
 

--- a/test/quantile.test.js
+++ b/test/quantile.test.js
@@ -31,19 +31,22 @@ test('quantile', function(t) {
         t.end();
     });
 
-    t.test('a zero-length list produces NaN', function(t) {
-        t.ok(isNaN(ss.quantile([], 0.5)));
-        t.end();
-    });
+    t.throws(function() {
+        ss.quantile([], 0.5);
+    }, 'a zero-length list throws an error');
 
     t.test('test odd-value case', function(t) {
         t.equal(ss.quantile([0, 1, 2, 3, 4], 0.2), 1);
         t.end();
     });
 
-    t.test('bad bounds produce NaN', function(t) {
-        t.ok(isNaN(ss.quantile([1, 2, 3], 1.1)));
-        t.ok(isNaN(ss.quantile([1, 2, 3], -0.5)));
+    t.test('bad bounds throw an error', function(t) {
+        t.throws(function() {
+            ss.quantile([1, 2, 3], 1.1);
+        });
+        t.throws(function() {
+            ss.quantile([1, 2, 3], -0.5);
+        });
         t.end();
     });
 

--- a/test/root_mean_square.test.js
+++ b/test/root_mean_square.test.js
@@ -18,7 +18,9 @@ test('root_mean_square', function(t) {
     });
 
     t.test('returns null for empty lists', function(t) {
-        t.ok(isNaN(ss.rootMeanSquare([])));
+        t.throws(function() {
+            ss.rootMeanSquare([]);
+        });
         t.end();
     });
 

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -24,7 +24,9 @@ test('sample correlation', function(t) {
     });
 
     t.test('zero-length corner case', function(t) {
-        t.ok(isNaN(ss.sampleCorrelation([], [])));
+        t.throws(function() {
+            ss.sampleCorrelation([], []);
+        });
         t.end();
     });
 

--- a/test/sample_covariance.test.js
+++ b/test/sample_covariance.test.js
@@ -30,7 +30,9 @@ test('sample covariance', function(t) {
     });
 
     t.test('zero-length corner case', function(t) {
-        t.ok(isNaN(ss.sampleCovariance([], [])));
+        t.throws(function() {
+            ss.sampleCovariance([], []);
+        });
         t.end();
     });
     t.end();

--- a/test/sample_skewness.test.js
+++ b/test/sample_skewness.test.js
@@ -8,19 +8,25 @@ test('sample skewness', function(t) {
 
     t.test('the skewness of an empty sample is null', function(t) {
         var data = [];
-        t.ok(isNaN(ss.sampleSkewness(data)));
+        t.throws(function() {
+            ss.sampleSkewness(data);
+        });
         t.end();
     });
 
     t.test('the skewness of an sample with one number is null', function(t) {
         var data = [1];
-        t.ok(isNaN(ss.sampleSkewness(data)));
+        t.throws(function() {
+            ss.sampleSkewness(data);
+        });
         t.end();
     });
 
     t.test('the skewness of an sample with two numbers is null', function(t) {
         var data = [1, 2];
-        t.ok(isNaN(ss.sampleSkewness(data)));
+        t.throws(function() {
+            ss.sampleSkewness(data);
+        });
         t.end();
     });
 

--- a/test/sample_standard_deviation.test.js
+++ b/test/sample_standard_deviation.test.js
@@ -14,9 +14,9 @@ test('sampleStandardDeviation', function(t) {
         t.end();
     });
 
-    t.test('zero-length corner case', function(t) {
-        t.ok(isNaN(ss.sampleStandardDeviation([])));
-        t.end();
-    });
+    t.throws(function() {
+        ss.sampleStandardDeviation([]);
+    }, 'zero-length corner case');
+
     t.end();
 });

--- a/test/sample_variance.test.js
+++ b/test/sample_variance.test.js
@@ -28,14 +28,13 @@ test('sample variance', function(t) {
         t.end();
     });
 
-    t.test('the sample variance of one number is null', function(t) {
-        t.ok(isNaN(ss.sampleVariance([1])));
-        t.end();
-    });
+    t.throws(function() {
+        ss.sampleVariance([1]);
+    }, 'the sample variance of one number cannot be calculated');
 
-    t.test('the sample variance of no numbers is null', function(t) {
-        t.ok(isNaN(ss.sampleVariance([])));
-        t.end();
-    });
+    t.throws(function() {
+        ss.sampleVariance([]);
+    }, 'the sample variance of no numbers cannot be calculated');
+
     t.end();
 });

--- a/test/standard_deviation.test.js
+++ b/test/standard_deviation.test.js
@@ -23,7 +23,9 @@ test('standardDeviation', function(t) {
     });
 
     t.test('zero-length array corner case', function(t) {
-        t.equal(rnd(ss.standardDeviation([])), 0);
+        t.throws(function() {
+            ss.standardDeviation([]);
+        });
         t.end();
     });
 

--- a/test/variance.test.js
+++ b/test/variance.test.js
@@ -19,8 +19,10 @@ test('variance', function(t) {
         t.end();
     });
 
-    t.test('the variance of no numbers is NaN', function(t) {
-        t.ok(isNaN(ss.variance([])));
+    t.test('the variance of no numbers cannot be calculated', function(t) {
+        t.throws(function () {
+            ss.variance([]);
+        });
         t.end();
     });
     t.end();


### PR DESCRIPTION
Fixes #179. This changes the way that simple-statistics handles invalid input, like trying to find the minimum element of `[]`. Instead of returning `NaN` like before, we will now throw Errors. This includes:

* [x] Updated tests to test with `t.throws` instead of `t.ok(isNaN`
* [x] Added error messages & throwing cases
* [x] Unified input variables from `sample` etc to `x`, always.
* [x] Prefer `<` to `<=` in length comparisons, so translation to/from english is easier
* [x] Determine why `test/standard_deviation.test.js` needed to be changed. Previously we allowed arrays that were too short to represent a meaningful variance to still produce a standard deviation of 0. This is fixed in the new changes - standard_deviation requires length>0, sample_standard_deviation requires length>1.
* [x] Copyedit error messages
* [x] Mark throwing methods with proper doc tags