### PR TITLE
Implementing the Kahan-Babuska algorithm

### DIFF
--- a/src/sum.js
+++ b/src/sum.js
@@ -2,15 +2,17 @@
 /* @flow */
 
 /**
- * Our default sum is the [Kahan summation algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm) is
- * a method for computing the sum of a list of numbers while correcting
- * for floating-point errors. Traditionally, sums are calculated as many
+ * Our default sum is the [Kahan-Babuska algorithm](https://pdfs.semanticscholar.org/1760/7d467cda1d0277ad272deb2113533131dc09.pdf).
+ * This method is an improvement over the classical
+ * [Kahan summation algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm).
+ * It aims at computing the sum of a list of numbers while correcting for
+ * floating-point errors. Traditionally, sums are calculated as many
  * successive additions, each one with its own floating-point roundoff. These
  * losses in precision add up as the number of numbers increases. This alternative
  * algorithm is more accurate than the simple way of calculating sums by simple
  * addition.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs on `O(n)`, linear time in respect to the array.
  *
  * @param {Array<number>} x input
  * @return {number} sum of all input numbers
@@ -19,43 +21,36 @@
  */
 function sum(x/*: Array<number> */)/*: number */ {
 
-    // like the traditional sum algorithm, we keep a running
-    // count of the current sum.
-    var sum = 0;
-
-    // but we also keep three extra variables as bookkeeping:
-    // most importantly, an error correction value. This will be a very
-    // small number that is the opposite of the floating point precision loss.
-    var errorCompensation = 0;
-
-    // this will be each number in the list corrected with the compensation value.
-    var correctedCurrentValue;
-
-    // and this will be the next sum
-    var nextSum;
-
-    for (var i = 0; i < x.length; i++) {
-        // first correct the value that we're going to add to the sum
-        correctedCurrentValue = x[i] - errorCompensation;
-
-        // compute the next sum. sum is likely a much larger number
-        // than correctedCurrentValue, so we'll lose precision here,
-        // and measure how much precision is lost in the next step
-        nextSum = sum + correctedCurrentValue;
-
-        // we intentionally didn't assign sum immediately, but stored
-        // it for now so we can figure out this: is (sum + nextValue) - nextValue
-        // not equal to 0? ideally it would be, but in practice it won't:
-        // it will be some very small number. that's what we record
-        // as errorCompensation.
-        errorCompensation = nextSum - sum - correctedCurrentValue;
-
-        // now that we've computed how much we'll correct for in the next
-        // loop, start treating the nextSum as the current sum.
-        sum = nextSum;
+    // If the array is empty, we needn't bother computing its sum
+    if (x.length === 0) {
+        return 0;
     }
 
-    return sum;
+    // Initializing the sum as the first number in the array
+    var sum = x[0];
+
+    // Keeping track of the floating-point error correction
+    var correction = 0;
+
+    var transition;
+
+    for (var i = 1; i < x.length; i++) {
+        transition = sum + x[i];
+
+        // Here we need to update the correction in a different fashion
+        // if the new absolute value is greater than the absolute sum
+        if (Math.abs(sum) >= Math.abs(x[i])) {
+            correction += ((sum - transition) + x[i]);
+        }
+        else {
+            correction += ((x[i] - transition) + sum);
+        }
+
+        sum = transition;
+    }
+
+    // Returning the corrected sum
+    return sum + correction;
 }
 
 module.exports = sum;


### PR DESCRIPTION
Hello `simple-statistics`.

I tried some things to improve the performance of the `sum` function without compromising the float rounding error correction and stumbled upon the Kahan-Babuska algorithm (you can read a description of the algorithm in [this](https://pdfs.semanticscholar.org/1760/7d467cda1d0277ad272deb2113533131dc09.pdf) paper).

It's faster because it can apply the correction at the end rather than at each iteration.

What do you think?