### PR TITLE
Return array instead of object in distribution functions

### DIFF
--- a/src/bernoulli_distribution.js
+++ b/src/bernoulli_distribution.js
@@ -13,18 +13,18 @@
  * where `n` = 1.
  *
  * @param {number} p input value, between 0 and 1 inclusive
- * @returns {number} value of bernoulli distribution at this point
+ * @returns {number[]} values of bernoulli distribution at this point
  * @throws {Error} if p is outside 0 and 1
  * @example
- * bernoulliDistribution(0.5); // => { '0': 0.5, '1': 0.5 }
+ * bernoulliDistribution(0.3); // => [0.7, 0.3]
  */
-function bernoulliDistribution(p/*: number */) {
+function bernoulliDistribution(p/*: number */) /*: number[] */ {
     // Check that `p` is a valid probability (0 ≤ p ≤ 1)
     if (p < 0 || p > 1 ) {
         throw new Error('bernoulliDistribution requires probability to be between 0 and 1 inclusive');
     }
 
-    return { '0': 1 - p, '1': p };
+    return [1 - p, p];
 }
 
 module.exports = bernoulliDistribution;

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -11,11 +11,11 @@ var epsilon = require('./epsilon');
  *
  * @param {number} trials number of trials to simulate
  * @param {number} probability
- * @returns {Object} output
+ * @returns {number[]} output
  */
 function binomialDistribution(
     trials/*: number */,
-    probability/*: number */)/*: ?Object */ {
+    probability/*: number */)/*: ?number[] */ {
     // Check that `p` is a valid probability (0 ≤ p ≤ 1),
     // that `n` is an integer, strictly positive.
     if (probability < 0 || probability > 1 ||
@@ -31,7 +31,7 @@ function binomialDistribution(
     // within `epsilon` of 1.0.
     var x = 0,
         cumulativeProbability = 0,
-        cells = {},
+        cells = [],
         binomialCoefficient = 1;
 
     // This algorithm iterates through each potential outcome,

--- a/src/poisson_distribution.js
+++ b/src/poisson_distribution.js
@@ -14,9 +14,9 @@ var epsilon = require('./epsilon');
  * mean arrival or occurrence rate, `λ`.
  *
  * @param {number} lambda location poisson distribution
- * @returns {number} value of poisson distribution at that point
+ * @returns {number[]} values of poisson distribution at that point
  */
-function poissonDistribution(lambda/*: number */) {
+function poissonDistribution(lambda/*: number */) /*: ?number[] */ {
     // Check that lambda is strictly positive
     if (lambda <= 0) { return undefined; }
 
@@ -26,7 +26,7 @@ function poissonDistribution(lambda/*: number */) {
         // order to know when to stop calculating chances.
         cumulativeProbability = 0,
         // the calculated cells to be returned
-        cells = {},
+        cells = [],
         factorialX = 1;
 
     // This algorithm iterates through each potential outcome,

--- a/test/bernoulli_distribution.test.js
+++ b/test/bernoulli_distribution.test.js
@@ -6,7 +6,7 @@ var ss = require('../');
 
 test('bernoulliDistribution', function(t) {
     t.test('can return generate probability and cumulative probability distributions for p = 0.3', function(t) {
-        t.equal('object', typeof ss.bernoulliDistribution(0.3));
+        t.ok(Array.isArray(ss.bernoulliDistribution(0.3)));
         t.equal(ss.bernoulliDistribution(0.3)[0], 0.7, ss.epsilon);
         t.equal(ss.bernoulliDistribution(0.3)[1], 0.3, ss.epsilon);
         t.end();


### PR DESCRIPTION
Makes `bernoulliDistribution`, `binomialDistribution` and `poissonDistribution` return an array instead of object. The result is fully requivalent since keys were sequential integers starting from 0, but this is ~5% faster.