### PR TITLE
Adds sampleKurtosis

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ ss.sampleCorrelation = require('./src/sample_correlation');
 ss.sampleVariance = require('./src/sample_variance');
 ss.sampleStandardDeviation = require('./src/sample_standard_deviation');
 ss.sampleSkewness = require('./src/sample_skewness');
+ss.sampleKurtosis = require('./src/sample_kurtosis');
 
 // combinatorics
 ss.permutationsHeap = require('./src/permutations_heap');

--- a/src/sample_kurtosis.js
+++ b/src/sample_kurtosis.js
@@ -1,0 +1,44 @@
+'use strict';
+/* @flow */
+
+var mean = require('./mean');
+
+/**
+ * [Kurtosis](http://en.wikipedia.org/wiki/Kurtosis) is
+ * a measure of the heaviness of a distribution's tails relative to its
+ * variance. The kurtosis value can be positive or negative, or even undefined.
+ *
+ * Implementation is based on Fisher's excess kurtosis definition and uses 
+ * unbiased moment estimators. This is the version found in Excel and available 
+ * in several statistical packages, including SAS and SciPy.
+ *
+ * @param {Array<number>} x a sample of 4 or more data points
+ * @returns {number} sample kurtosis
+ * @throws {Error} if x has length less than 4
+ * @example
+ * sampleKurtosis([1, 2, 2, 3, 5]); // => 1.4555765595463122
+ */
+function sampleKurtosis(x /*: Array<number> */)/*:number*/ {
+
+    var n = x.length;
+
+    if (n < 4) {
+        throw new Error('sampleKurtosis requires at least four data points');
+    }
+
+    var meanValue = mean(x);
+    var tempValue;
+    var secondCentralMoment = 0;
+    var fourthCentralMoment = 0;
+
+    for (var i = 0; i < n; i++) {
+        tempValue = x[i] - meanValue;
+        secondCentralMoment += tempValue * tempValue;
+        fourthCentralMoment += tempValue * tempValue * tempValue * tempValue;
+    }
+
+    return (n - 1) / ((n - 2) * (n - 3)) * 
+        (n * (n + 1) * fourthCentralMoment / (secondCentralMoment * secondCentralMoment) - 3 * (n - 1));
+}
+
+module.exports = sampleKurtosis;

--- a/test/sample_kurtosis.test.js
+++ b/test/sample_kurtosis.test.js
@@ -1,0 +1,74 @@
+/* eslint no-shadow: 0 */
+'use strict';
+
+var test = require('tap').test;
+var ss = require('../');
+
+test('sample kurtosis', function(t) {
+
+    t.test('the kurtosis of an empty sample is null', function(t) {
+        var data = [];
+        t.throws(function() {
+            ss.sampleKurtosis(data);
+        });
+        t.end();
+    });
+
+    t.test('the kurtosis of an sample with one number is null', function(t) {
+        var data = [1];
+        t.throws(function() {
+            ss.sampleKurtosis(data);
+        });
+        t.end();
+    });
+
+    t.test('the kurtosis of an sample with two numbers is null', function(t) {
+        var data = [1, 2];
+        t.throws(function() {
+            ss.sampleKurtosis(data);
+        });
+        t.end();
+    });
+
+    t.test('the kurtosis of an sample with three numbers is null', function(t) {
+        var data = [1, 2, 3];
+        t.throws(function() {
+            ss.sampleKurtosis(data);
+        });
+        t.end();
+    });
+
+    t.test('can calculate the kurtosis of SAS example 1', function(t) {
+        // Data and answer taken from KURTOSIS function documentation at
+        // https://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/viewer.htm#a000245906.htm
+        var data = [5, 9, 3, 6];
+        t.equal(+ss.sampleKurtosis(data).toPrecision(10), 0.9280000000);
+        t.end();
+    });
+
+    t.test('can calculate the kurtosis of SAS example 2', function(t) {
+        // Data and answer taken from KURTOSIS function documentation at
+        // https://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/viewer.htm#a000245906.htm
+        var data = [5, 8, 9, 6];
+        t.equal(+ss.sampleKurtosis(data).toPrecision(10), -3.3000000000);
+        t.end();
+    });
+
+    t.test('can calculate the kurtosis of SAS example 3', function(t) {
+        // Data and answer taken from KURTOSIS function documentation at
+        // https://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/viewer.htm#a000245906.htm
+        var data = [8, 9, 6, 1];
+        t.equal(+ss.sampleKurtosis(data).toPrecision(10), 1.5000000000);
+        t.end();
+    });
+    t.end();
+
+    t.test('can calculate the kurtosis of SAS example 4', function(t) {
+        // Data and answer taken from KURTOSIS function documentation at
+        // https://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/viewer.htm#a000245906.htm
+        var data = [8, 1, 6, 1];
+        t.equal(+ss.sampleKurtosis(data).toPrecision(10), -4.483379501);
+        t.end();
+    });
+    t.end();
+});

--- a/test/sample_kurtosis.test.js
+++ b/test/sample_kurtosis.test.js
@@ -61,7 +61,6 @@ test('sample kurtosis', function(t) {
         t.equal(+ss.sampleKurtosis(data).toPrecision(10), 1.5000000000);
         t.end();
     });
-    t.end();
 
     t.test('can calculate the kurtosis of SAS example 4', function(t) {
         // Data and answer taken from KURTOSIS function documentation at


### PR DESCRIPTION
Uses Fisher’s excess kurtosis definition with unbiased central moment
estimators (used in Excel and SAS, also SciPy’s stats.kurtosis when
bias=False). Pretty similar to sampleSkewness.

Fixes #218 