### PR TITLE
docs: Very detailed installation directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,27 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
 
 ## Installation
 
-**Recommended**: for [node.js](https://nodejs.org/), [browserify](http://browserify.org/),
-and/or [webpack](http://webpack.github.io/) users, install from npm:
-
-    npm install simple-statistics
-
-Script tag usage:
-
-* `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.js`
-* Minified: `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.min.js`
-
-Bower:
-
-* Bower: `https://unpkg.com/simple-statistics@4.1.0/bower.zip`
+* **I'm using Node.js, Webpack, Browserify, Rollup, or another module bundler,
+  and install packages from npm.**
+  * First, install the `simple-statistics` module, using `npm install simple-statistics`,
+    then include the code with require or import:
+  * **I use the `require` function to use modules in my project. (most likely)**
+    * When you use `require`, you have the freedom to assign the module to any
+      variable name you want, but you need to specify the module's name exactly:
+      in this case, 'simple-statistics'. The `require` method returns an object
+      with all of the module's methods attached to it.<br /> <pre>var ss = require('simple-statistics')</pre>
+  * **I use `import` to use modules in my project. I'm probably using Babel, Webpack, or Rollup.**
+    * This module only supports the 'default' export when you're using ES6 module:
+      so you can import all of its methods, attached to an object, like in
+      this example. Importing specific methods will work in Babel, but not
+      in Rollup.<br /> <pre>import ss from 'simple-statistics';</pre>
+* **I'm not using a module bundler. I'm writing a web page, and want to include
+  simple-statistics using a script tag.**
+  * When you use simple-statistics from a script tag, you don't get to choose
+    the variable name it is assigned to: simple-statistics will always become
+    available globally as the variable `ss`. You can reassign this variable to
+    another name if you want to, but doing so is optional. <pre><script src='https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.js' /></pre>
+    There are two options for the `src` attribute of that script tag: one with
+    `.min.js` that is compressed, and the other without, that is raw.
+    * `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.js`
+    * `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.min.js`


### PR DESCRIPTION
This also removes the bower installation method, because it was dropped by unpkg. This documentation
now shows how to install and use simple-statistics, and is super, super explicit about how to use
it, I hope.

Fixes #227