### PR TITLE
Implement ES6 modules - Fixes #210

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,10 @@ module.exports = {
         "node": true
     },
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
     "rules": {
         "accessor-pairs": "error",
         "array-bracket-spacing": [

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+.*/node_modules/documentation/.*
 .*/node_modules/config-chain/test/.*
 .*/node_modules/conventional-changelog-core/test/.*
 .*/node_modules/.cache.*

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-coverage
-test
-docs
-benchmarks

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
   * When you use simple-statistics from a script tag, you don't get to choose
     the variable name it is assigned to: simple-statistics will always become
     available globally as the variable `ss`. You can reassign this variable to
-    another name if you want to, but doing so is optional. <pre><script src='https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.js' /></pre>
+    another name if you want to, but doing so is optional. <pre><script src='https://unpkg.com/simple-statistics@4.1.1/dist/simple-statistics.js' /></pre>
     There are two options for the `src` attribute of that script tag: one with
     `.min.js` that is compressed, and the other without, that is raw.
-    * `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.js`
-    * `https://unpkg.com/simple-statistics@4.1.0/dist/simple-statistics.min.js`
+    * `https://unpkg.com/simple-statistics@4.1.1/dist/simple-statistics.js`
+    * `https://unpkg.com/simple-statistics@4.1.1/dist/simple-statistics.min.js`

--- a/index.js
+++ b/index.js
@@ -1,91 +1,93 @@
 /* @flow */
-'use strict';
 
 // # simple-statistics
 //
 // A simple, literate statistics system.
 
-var ss = module.exports = {};
-
 // Linear Regression
-ss.linearRegression = require('./src/linear_regression');
-ss.linearRegressionLine = require('./src/linear_regression_line');
-ss.standardDeviation = require('./src/standard_deviation');
-ss.rSquared = require('./src/r_squared');
-ss.mode = require('./src/mode');
-ss.modeFast = require('./src/mode_fast');
-ss.modeSorted = require('./src/mode_sorted');
-ss.min = require('./src/min');
-ss.max = require('./src/max');
-ss.minSorted = require('./src/min_sorted');
-ss.maxSorted = require('./src/max_sorted');
-ss.sum = require('./src/sum');
-ss.sumSimple = require('./src/sum_simple');
-ss.product = require('./src/product');
-ss.quantile = require('./src/quantile');
-ss.quantileSorted = require('./src/quantile_sorted');
-ss.interquartileRange = ss.iqr = require('./src/interquartile_range');
-ss.medianAbsoluteDeviation = ss.mad = require('./src/median_absolute_deviation');
-ss.chunk = require('./src/chunk');
-ss.sampleWithReplacement = require('./src/sample_with_replacement');
-ss.shuffle = require('./src/shuffle');
-ss.shuffleInPlace = require('./src/shuffle_in_place');
-ss.sample = require('./src/sample');
-ss.ckmeans = require('./src/ckmeans');
-ss.uniqueCountSorted = require('./src/unique_count_sorted');
-ss.sumNthPowerDeviations = require('./src/sum_nth_power_deviations');
-ss.equalIntervalBreaks = require('./src/equal_interval_breaks');
+export { default as linearRegression } from './src/linear_regression';
+export { default as linearRegressionLine } from './src/linear_regression_line';
+export { default as standardDeviation } from './src/standard_deviation';
+export { default as rSquared } from './src/r_squared';
+export { default as mode } from './src/mode';
+export { default as modeFast } from './src/mode_fast';
+export { default as modeSorted } from './src/mode_sorted';
+export { default as min } from './src/min';
+export { default as max } from './src/max';
+export { default as minSorted } from './src/min_sorted';
+export { default as maxSorted } from './src/max_sorted';
+export { default as sum } from './src/sum';
+export { default as sumSimple } from './src/sum_simple';
+export { default as product } from './src/product';
+export { default as quantile } from './src/quantile';
+export { default as quantileSorted } from './src/quantile_sorted';
+export { default as interquartileRange, default as iqr } from './src/interquartile_range';
+export { default as medianAbsoluteDeviation, default as mad } from './src/median_absolute_deviation';
+export { default as chunk } from './src/chunk';
+export { default as sampleWithReplacement } from './src/sample_with_replacement';
+export { default as shuffle } from './src/shuffle';
+export { default as shuffleInPlace } from './src/shuffle_in_place';
+export { default as sample } from './src/sample';
+export { default as ckmeans } from './src/ckmeans';
+export { default as uniqueCountSorted } from './src/unique_count_sorted';
+export { default as sumNthPowerDeviations } from './src/sum_nth_power_deviations';
+export { default as equalIntervalBreaks } from './src/equal_interval_breaks';
 
 // sample statistics
-ss.sampleCovariance = require('./src/sample_covariance');
-ss.sampleCorrelation = require('./src/sample_correlation');
-ss.sampleVariance = require('./src/sample_variance');
-ss.sampleStandardDeviation = require('./src/sample_standard_deviation');
-ss.sampleSkewness = require('./src/sample_skewness');
-ss.sampleKurtosis = require('./src/sample_kurtosis');
+export { default as sampleCovariance } from './src/sample_covariance';
+export { default as sampleCorrelation } from './src/sample_correlation';
+export { default as sampleVariance } from './src/sample_variance';
+export { default as sampleStandardDeviation } from './src/sample_standard_deviation';
+export { default as sampleSkewness } from './src/sample_skewness';
+export { default as sampleKurtosis } from './src/sample_kurtosis';
 
 // combinatorics
-ss.permutationsHeap = require('./src/permutations_heap');
-ss.combinations = require('./src/combinations');
-ss.combinationsReplacement = require('./src/combinations_replacement');
+export { default as permutationsHeap } from './src/permutations_heap';
+export { default as combinations } from './src/combinations';
+export { default as combinationsReplacement } from './src/combinations_replacement';
 
 // measures of centrality
-ss.addToMean = require('./src/add_to_mean');
-ss.combineMeans = require('./src/combine_means');
-ss.combineVariances = require('./src/combine_variances');
-ss.geometricMean = require('./src/geometric_mean');
-ss.harmonicMean = require('./src/harmonic_mean');
-ss.mean = ss.average = require('./src/mean');
-ss.median = require('./src/median');
-ss.medianSorted = require('./src/median_sorted');
-ss.subtractFromMean = require('./src/subtract_from_mean');
+export { default as addToMean } from './src/add_to_mean';
+export { default as combineMeans } from './src/combine_means';
+export { default as combineVariances } from './src/combine_variances';
+export { default as geometricMean } from './src/geometric_mean';
+export { default as harmonicMean } from './src/harmonic_mean';
+export { default as average, default as mean } from './src/mean';
+export { default as median } from './src/median';
+export { default as medianSorted } from './src/median_sorted';
+export { default as subtractFromMean } from './src/subtract_from_mean';
 
-ss.rootMeanSquare = ss.rms = require('./src/root_mean_square');
-ss.variance = require('./src/variance');
-ss.tTest = require('./src/t_test');
-ss.tTestTwoSample = require('./src/t_test_two_sample');
+export { default as rootMeanSquare, default as rms } from './src/root_mean_square';
+export { default as variance } from './src/variance';
+export { default as tTest } from './src/t_test';
+export { default as tTestTwoSample } from './src/t_test_two_sample';
 // ss.jenks = require('./src/jenks');
 
 // Classifiers
-ss.BayesianClassifier = ss.bayesian = require('./src/bayesian_classifier');
-ss.PerceptronModel = ss.perceptron = require('./src/perceptron');
+export { default as BayesianClassifier, default as bayesian } from './src/bayesian_classifier';
+export { default as PerceptronModel, default as perceptron } from './src/perceptron';
 
 // Distribution-related methods
-ss.epsilon = require('./src/epsilon'); // We make ε available to the test suite.
-ss.factorial = require('./src/factorial');
-ss.bernoulliDistribution = require('./src/bernoulli_distribution');
-ss.binomialDistribution = require('./src/binomial_distribution');
-ss.poissonDistribution = require('./src/poisson_distribution');
-ss.chiSquaredGoodnessOfFit = require('./src/chi_squared_goodness_of_fit');
-ss.kernelDensityEstimation = require('./src/kernel_density_estimation');
+export { default as epsilon } from './src/epsilon'; // We make ε available to the test suite.
+export { default as factorial } from './src/factorial';
+export { default as bernoulliDistribution } from './src/bernoulli_distribution';
+export { default as binomialDistribution } from './src/binomial_distribution';
+export { default as poissonDistribution } from './src/poisson_distribution';
+export { default as chiSquaredGoodnessOfFit } from './src/chi_squared_goodness_of_fit';
+export { default as kernelDensityEstimation } from './src/kernel_density_estimation';
 
 // Normal distribution
-ss.zScore = require('./src/z_score');
-ss.cumulativeStdNormalProbability = require('./src/cumulative_std_normal_probability');
-ss.standardNormalTable = require('./src/standard_normal_table');
-ss.errorFunction = ss.erf = require('./src/error_function');
-ss.inverseErrorFunction = require('./src/inverse_error_function');
-ss.probit = require('./src/probit');
+export { default as zScore } from './src/z_score';
+export { default as cumulativeStdNormalProbability } from './src/cumulative_std_normal_probability';
+export { default as standardNormalTable } from './src/standard_normal_table';
+export { default as errorFunction, default as erf } from './src/error_function';
+export { default as inverseErrorFunction } from './src/inverse_error_function';
+export { default as probit } from './src/probit';
 
 // Root-finding methods
-ss.bisect = require('./src/bisect');
+export { default as bisect } from './src/bisect';
+
+// Utils
+export { default as quickselect } from './src/quickselect';
+export { default as sign } from './src/sign';
+export { default as numericSort } from './src/numeric_sort';

--- a/package.json
+++ b/package.json
@@ -15,30 +15,30 @@
   "dependencies": {},
   "devDependencies": {
     "are-we-flow-yet": "^1.0.0",
-    "browserify": "^14.1.0",
-    "bundle-collapser": "^1.0.0",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^4.1.0",
-    "exorcist": "^0.4.0",
     "flow-bin": "^0.53.0",
-    "jsdoctest": "https://github.com/yamadapc/jsdoctest/archive/2313d157117b31e1b862375c26445f3befcfab23.tar.gz",
-    "mocha": "3.5.3",
     "random-js": "^1.0.4",
+    "rollup": "^0.50.0",
+    "rollup-plugin-uglify": "^2.0.1",
     "standard-version": "^4.0.0",
     "tap": "^10.1.1",
     "uglify-js": "^3.0.0"
   },
   "scripts": {
     "release": "standard-version && sh ./scripts/update_website.sh",
-    "test": "are-we-flow-yet src && flow check src && eslint index.js src/*.js test/*.js && tap --coverage test/*.js && npm run jsdoctest",
+    "pretest": "npm run build",
+    "test": "npm run lint && tap --coverage test/*.js",
     "test-sauce": "node scripts/browser_test.js",
-    "build": "npm run bundle && npm run minify",
+    "build": "rm -rf dist && mkdir dist && rollup -c",
     "prepublish": "npm run build && ./scripts/update_readme.js",
-    "bundle": "mkdir -p dist && browserify -p bundle-collapser/plugin -s ss index.js --debug | exorcist dist/simple-statistics.js.map > dist/simple-statistics.js",
-    "minify": "uglifyjs dist/simple-statistics.js -c -m --source-map content=dist/simple-statistics.js.map -o dist/simple-statistics.min.js",
-    "jsdoctest": "mocha --require jsdoctest index.js"
+    "prelint": "are-we-flow-yet src && flow check src",
+    "lint": "eslint index.js src test",
+    "postlint": "documentation lint src"
   },
-  "main": "index.js",
+  "main": "dist/simple-statistics.js",
+  "module": "index",
+  "jsnext:main": "index",
   "engines": {
     "node": "*"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "are-we-flow-yet": "^1.0.0",
     "cz-conventional-changelog": "^2.0.0",
+    "documentation": "^5.3.2",
     "eslint": "^4.1.0",
     "flow-bin": "^0.53.0",
     "random-js": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "documentation": "^5.3.2",
     "eslint": "^4.1.0",
     "flow-bin": "^0.53.0",
+    "jsdoctest": "^1.7.1",
+    "mocha": "^3.5.3",
     "random-js": "^1.0.4",
     "rollup": "^0.50.0",
     "rollup-plugin-uglify": "^2.0.1",
@@ -29,15 +31,15 @@
   "scripts": {
     "release": "standard-version && sh ./scripts/update_website.sh",
     "pretest": "npm run build",
-    "test": "npm run lint && tap --coverage test/*.js",
-    "test-sauce": "node scripts/browser_test.js",
+    "test": "npm run lint && tap --coverage test/*.js && npm run jsdoctest",
     "build": "rm -rf dist && mkdir dist && rollup -c",
     "prepublish": "npm run build && ./scripts/update_readme.js",
     "prelint": "are-we-flow-yet src && flow check src",
     "lint": "eslint index.js src test",
-    "postlint": "documentation lint src"
+    "postlint": "documentation lint src",
+    "jsdoctest": "mocha --require jsdoctest dist/index.js"
   },
-  "main": "dist/simple-statistics.js",
+  "main": "dist/index",
   "module": "index",
   "jsnext:main": "index",
   "engines": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,24 @@
+import uglify from 'rollup-plugin-uglify';
+
+export default [{
+    input: 'index',
+    output: {
+        extend: true,
+        sourcemap: true,
+        file: 'dist/simple-statistics.js',
+        format: 'umd',
+        name: 'ss'
+    }
+}, {
+    input: 'index',
+    output: {
+        extend: true,
+        sourcemap: true,
+        file: 'dist/simple-statistics.min.js',
+        format: 'umd',
+        name: 'ss'
+    },
+    plugins: [
+        uglify()
+    ]
+}];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,14 @@ export default [{
     output: {
         extend: true,
         sourcemap: true,
+        file: 'dist/index.js',
+        format: 'cjs'
+    }
+}, {
+    input: 'index',
+    output: {
+        extend: true,
+        sourcemap: true,
         file: 'dist/simple-statistics.min.js',
         format: 'umd',
         name: 'ss'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,32 +1,20 @@
 import uglify from 'rollup-plugin-uglify';
 
-export default [{
-    input: 'index',
-    output: {
-        extend: true,
-        sourcemap: true,
-        file: 'dist/simple-statistics.js',
-        format: 'umd',
-        name: 'ss'
+function assign({ file, format, plugins }) {
+    return {
+        input: 'index',
+        output: {
+            file,
+            format: format || 'umd',
+            extend: true,
+            sourcemap: true,
+            name: 'ss'
+        },
+        plugins: plugins || []
     }
-}, {
-    input: 'index',
-    output: {
-        extend: true,
-        sourcemap: true,
-        file: 'dist/index.js',
-        format: 'cjs'
-    }
-}, {
-    input: 'index',
-    output: {
-        extend: true,
-        sourcemap: true,
-        file: 'dist/simple-statistics.min.js',
-        format: 'umd',
-        name: 'ss'
-    },
-    plugins: [
-        uglify()
-    ]
-}];
+}
+export default [
+    assign({ file: 'dist/simple-statistics.js' }),
+    assign({ file: 'dist/simple-statistics.min.js', plugins: [uglify()] }),
+    assign({ format: 'cjs', file: 'dist/index.js' })
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,10 @@
 import uglify from 'rollup-plugin-uglify';
 
-function assign({ file, format, plugins }) {
+function assign(options) {
+    const file = options.file
+    const format = options.format
+    const plugins = options.plugins
+
     return {
         input: 'index',
         output: {

--- a/src/add_to_mean.js
+++ b/src/add_to_mean.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -21,4 +20,4 @@ function addToMean(mean /*: number*/, n/*: number */, newValue/*: number */)/*: 
     return mean + ((newValue - mean) / (n + 1));
 }
 
-module.exports = addToMean;
+export default addToMean;

--- a/src/bayesian_classifier.js
+++ b/src/bayesian_classifier.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -113,4 +112,4 @@ BayesianClassifier.prototype.score = function(item) {
     return oddsSums;
 };
 
-module.exports = BayesianClassifier;
+export default BayesianClassifier;

--- a/src/bernoulli_distribution.js
+++ b/src/bernoulli_distribution.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -27,4 +26,4 @@ function bernoulliDistribution(p/*: number */) /*: number[] */ {
     return [1 - p, p];
 }
 
-module.exports = bernoulliDistribution;
+export default bernoulliDistribution;

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var epsilon = require('./epsilon');
+import epsilon from './epsilon';
 
 /**
  * The [Binomial Distribution](http://en.wikipedia.org/wiki/Binomial_distribution) is the discrete probability
@@ -51,4 +50,4 @@ function binomialDistribution(
     return cells;
 }
 
-module.exports = binomialDistribution;
+export default binomialDistribution;

--- a/src/bisect.js
+++ b/src/bisect.js
@@ -1,21 +1,21 @@
-'use strict';
 /* @flow */
 
-var sign = require('./sign');
+import sign from './sign';
+
 /**
- * [Bisection method](https://en.wikipedia.org/wiki/Bisection_method) is a root-finding 
+ * [Bisection method](https://en.wikipedia.org/wiki/Bisection_method) is a root-finding
  * method that repeatedly bisects an interval to find the root.
- * 
+ *
  * This function returns a numerical approximation to the exact value.
- * 
+ *
  * @param {Function} func input function
- * @param {Number} start - start of interval
- * @param {Number} end - end of interval
- * @param {Number} maxIterations - the maximum number of iterations
- * @param {Number} errorTolerance - the error tolerance
- * @returns {Number} estimated root value
+ * @param {number} start - start of interval
+ * @param {number} end - end of interval
+ * @param {number} maxIterations - the maximum number of iterations
+ * @param {number} errorTolerance - the error tolerance
+ * @returns {number} estimated root value
  * @throws {TypeError} Argument func must be a function
- * 
+ *
  * @example
  * bisect(Math.cos,0,4,100,0.003); // => 1.572265625
  */
@@ -27,7 +27,7 @@ function bisect(
     errorTolerance/*: number */)/*:number*/ {
 
     if (typeof func !== 'function') throw new TypeError('func must be a function');
-    
+
     for (var i = 0; i < maxIterations; i++) {
         var output = (start + end) / 2;
 
@@ -41,8 +41,8 @@ function bisect(
             end = output;
         }
     }
-    
+
     throw new Error('maximum number of iterations exceeded');
 }
 
-module.exports = bisect;
+export default bisect;

--- a/src/chi_squared_distribution_table.js
+++ b/src/chi_squared_distribution_table.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -496,4 +495,4 @@ var chiSquaredDistributionTable = {
     }
 };
 
-module.exports = chiSquaredDistributionTable;
+export default chiSquaredDistributionTable;

--- a/src/chi_squared_goodness_of_fit.js
+++ b/src/chi_squared_goodness_of_fit.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
-var chiSquaredDistributionTable = require('./chi_squared_distribution_table');
+import chiSquaredDistributionTable from './chi_squared_distribution_table';
+import mean from './mean';
 
 /**
  * The [χ2 (Chi-Squared) Goodness-of-Fit Test](http://en.wikipedia.org/wiki/Goodness_of_fit#Pearson.27s_chi-squared_test)
@@ -106,4 +105,4 @@ function chiSquaredGoodnessOfFit(
     return chiSquaredDistributionTable[degreesOfFreedom][significance] < chiSquared;
 }
 
-module.exports = chiSquaredGoodnessOfFit;
+export default chiSquaredGoodnessOfFit;

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -47,4 +46,4 @@ function chunk(x/*:Array<any>*/, chunkSize/*:number*/)/*:?Array<Array<any>>*/ {
     return output;
 }
 
-module.exports = chunk;
+export default chunk;

--- a/src/ckmeans.js
+++ b/src/ckmeans.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var uniqueCountSorted = require('./unique_count_sorted'),
-    numericSort = require('./numeric_sort');
+import numericSort from './numeric_sort';
+import uniqueCountSorted from './unique_count_sorted';
 
 /**
  * Create a new column x row matrix.
@@ -268,4 +267,4 @@ function ckmeans(x/*: Array<number> */, nClusters/*: number */)/*: Array<Array<n
     return clusters;
 }
 
-module.exports = ckmeans;
+export default ckmeans;

--- a/src/combinations.js
+++ b/src/combinations.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict';
+
 /**
  * Implementation of Combinations
  * Combinations are unique subsets of a collection - in this case, k x from a collection at a time.
@@ -33,4 +33,4 @@ function combinations(x /*: Array<any> */, k/*: number */) {
     return combinationList;
 }
 
-module.exports = combinations;
+export default combinations;

--- a/src/combinations_replacement.js
+++ b/src/combinations_replacement.js
@@ -1,12 +1,11 @@
 /* @flow */
-'use strict';
 
 /**
  * Implementation of [Combinations](https://en.wikipedia.org/wiki/Combination) with replacement
  * Combinations are unique subsets of a collection - in this case, k x from a collection at a time.
  * 'With replacement' means that a given element can be chosen multiple times.
  * Unlike permutation, order doesn't matter for combinations.
- * 
+ *
  * @param {Array} x any type of data
  * @param {int} k the number of objects in each group (without replacement)
  * @returns {Array<Array>} array of permutations
@@ -46,4 +45,4 @@ function combinationsReplacement(
     return combinationList;
 }
 
-module.exports = combinationsReplacement;
+export default combinationsReplacement;

--- a/src/combine_means.js
+++ b/src/combine_means.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -22,4 +21,4 @@ function combineMeans(mean1 /*: number*/, n1/*: number */, mean2 /*: number*/, n
     return (mean1 * n1 + mean2 * n2) / (n1 + n2);
 }
 
-module.exports = combineMeans;
+export default combineMeans;

--- a/src/combine_variances.js
+++ b/src/combine_variances.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var combineMeans = require('./combine_means')
+import combineMeans from './combine_means';
 
 /**
  * When combining two lists of values for which one already knows the variances,
@@ -38,4 +37,4 @@ function combineVariances(
     ) / (n1 + n2);
 }
 
-module.exports = combineVariances;
+export default combineVariances;

--- a/src/cumulative_std_normal_probability.js
+++ b/src/cumulative_std_normal_probability.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var standardNormalTable = require('./standard_normal_table');
+import standardNormalTable from './standard_normal_table';
 
 /**
  * **[Cumulative Standard Normal Probability](http://en.wikipedia.org/wiki/Standard_normal_table)**
@@ -40,4 +39,4 @@ function cumulativeStdNormalProbability(z /*:number */)/*:number */ {
     }
 }
 
-module.exports = cumulativeStdNormalProbability;
+export default cumulativeStdNormalProbability;

--- a/src/epsilon.js
+++ b/src/epsilon.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -37,4 +36,4 @@
  */
 var epsilon = 0.0001;
 
-module.exports = epsilon;
+export default epsilon;

--- a/src/equal_interval_breaks.js
+++ b/src/equal_interval_breaks.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var max = require('./max'),
-    min = require('./min');
+import max from './max';
+import min from './min';
 
 /**
  * Given an array of x, this will find the extent of the
@@ -23,8 +22,8 @@ function equalIntervalBreaks(x/*: Array<number> */, nClasses/*:number*/)/*: Arra
         return x;
     }
 
-    var theMin = min(x),
-        theMax = max(x); 
+    var theMin = min(x);
+    var theMax = max(x);
 
     // the first break will always be the minimum value
     // in the xset
@@ -47,4 +46,4 @@ function equalIntervalBreaks(x/*: Array<number> */, nClasses/*:number*/)/*: Arra
     return breaks;
 }
 
-module.exports = equalIntervalBreaks;
+export default equalIntervalBreaks;

--- a/src/error_function.js
+++ b/src/error_function.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -34,4 +33,4 @@ function errorFunction(x/*: number */)/*: number */ {
     }
 }
 
-module.exports = errorFunction;
+export default errorFunction;

--- a/src/factorial.js
+++ b/src/factorial.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -37,4 +36,4 @@ function factorial(n /*: number */)/*: number */ {
     return accumulator;
 }
 
-module.exports = factorial;
+export default factorial;

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -57,4 +56,4 @@ function geometricMean(x /*: Array<number> */) {
     return Math.pow(value, 1 / x.length);
 }
 
-module.exports = geometricMean;
+export default geometricMean;

--- a/src/harmonic_mean.js
+++ b/src/harmonic_mean.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -40,4 +39,4 @@ function harmonicMean(x /*: Array<number> */) {
     return x.length / reciprocalSum;
 }
 
-module.exports = harmonicMean;
+export default harmonicMean;

--- a/src/interquartile_range.js
+++ b/src/interquartile_range.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var quantile = require('./quantile');
+import quantile from './quantile';
 
 /**
  * The [Interquartile range](http://en.wikipedia.org/wiki/Interquartile_range) is
@@ -26,4 +25,4 @@ function interquartileRange(x/*: Array<number> */) {
     }
 }
 
-module.exports = interquartileRange;
+export default interquartileRange;

--- a/src/inverse_error_function.js
+++ b/src/inverse_error_function.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -24,4 +23,4 @@ function inverseErrorFunction(x/*: number */)/*: number */ {
     }
 }
 
-module.exports = inverseErrorFunction;
+export default inverseErrorFunction;

--- a/src/kernel_density_estimation.js
+++ b/src/kernel_density_estimation.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var stddev = require('./sample_standard_deviation');
-var interquartileRange = require('./interquartile_range');
+import interquartileRange from './interquartile_range';
+import stddev from './sample_standard_deviation';
 
 var SQRT_2PI = Math.sqrt(2 * Math.PI);
 
@@ -47,6 +46,7 @@ var bandwidthMethods /*: {[string]: (Array<number>) => number} */ = {
  * is a useful tool for, among other things, estimating the shape of the
  * underlying probability distribution from a sample.
  *
+ * @name kde
  * @param X sample values
  * @param kernel The kernel function to use. If a function is provided, it should return non-negative values and integrate to 1. Defaults to 'gaussian'.
  * @param bandwidthMethod The "bandwidth selection" method to use, or a fixed bandwidth value. Defaults to "nrd", the commonly-used ["normal reference distribution" rule-of-thumb](https://stat.ethz.ch/R-manual/R-devel/library/MASS/html/bandwidth.nrd.html).
@@ -91,4 +91,4 @@ function kde(
     }
 }
 
-module.exports = kde;
+export default kde;

--- a/src/linear_regression.js
+++ b/src/linear_regression.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -69,4 +68,4 @@ function linearRegression(data/*: Array<Array<number>> */)/*: { m: number, b: nu
 }
 
 
-module.exports = linearRegression;
+export default linearRegression;

--- a/src/linear_regression_line.js
+++ b/src/linear_regression_line.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -27,4 +26,4 @@ function linearRegressionLine(mb/*: { b: number, m: number }*/)/*: Function */ {
     };
 }
 
-module.exports = linearRegressionLine;
+export default linearRegressionLine;

--- a/src/max.js
+++ b/src/max.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -30,4 +29,4 @@ function max(x /*: Array<number> */) /*:number*/ {
     return value;
 }
 
-module.exports = max;
+export default max;

--- a/src/max_sorted.js
+++ b/src/max_sorted.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -15,4 +14,4 @@ function maxSorted(x /*: Array<number> */)/*:number*/ {
     return x[x.length - 1];
 }
 
-module.exports = maxSorted;
+export default maxSorted;

--- a/src/mean.js
+++ b/src/mean.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var sum = require('./sum');
+import sum from './sum';
 
 /**
  * The mean, _also known as average_,
@@ -26,4 +25,4 @@ function mean(x /*: Array<number> */)/*:number*/ {
     return sum(x) / x.length;
 }
 
-module.exports = mean;
+export default mean;

--- a/src/median.js
+++ b/src/median.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var quantile = require('./quantile');
+import quantile from './quantile';
 
 /**
  * The [median](http://en.wikipedia.org/wiki/Median) is
@@ -23,4 +22,4 @@ function median(x /*: Array<number> */)/*:number*/ {
     return +quantile(x, 0.5);
 }
 
-module.exports = median;
+export default median;

--- a/src/median_absolute_deviation.js
+++ b/src/median_absolute_deviation.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var median = require('./median');
+import median from './median';
 
 /**
  * The [Median Absolute Deviation](http://en.wikipedia.org/wiki/Median_absolute_deviation) is
@@ -27,4 +26,4 @@ function medianAbsoluteDeviation(x /*: Array<number> */) {
     return median(medianAbsoluteDeviations);
 }
 
-module.exports = medianAbsoluteDeviation;
+export default medianAbsoluteDeviation;

--- a/src/median_sorted.js
+++ b/src/median_sorted.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var quantileSorted = require('./quantile_sorted');
+import quantileSorted from './quantile_sorted';
 
 /**
  * The [median](http://en.wikipedia.org/wiki/Median) is
@@ -23,4 +22,4 @@ function medianSorted(sorted /*: Array<number> */)/*:number*/ {
     return quantileSorted(sorted, 0.5);
 }
 
-module.exports = medianSorted;
+export default medianSorted;

--- a/src/min.js
+++ b/src/min.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -27,4 +26,4 @@ function min(x /*: Array<number> */)/*:number*/ {
     return value;
 }
 
-module.exports = min;
+export default min;

--- a/src/min_sorted.js
+++ b/src/min_sorted.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -15,4 +14,4 @@ function minSorted(x /*: Array<number> */)/*:number*/ {
     return x[0];
 }
 
-module.exports = minSorted;
+export default minSorted;

--- a/src/mode.js
+++ b/src/mode.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var numericSort = require('./numeric_sort'),
-    modeSorted = require('./mode_sorted');
+import modeSorted from './mode_sorted';
+import numericSort from './numeric_sort';
 
 /**
  * The [mode](http://bit.ly/W5K4Yt) is the number that appears in a list the highest number of times.
@@ -27,4 +26,4 @@ function mode(x /*: Array<number> */)/*:number*/ {
     return modeSorted(numericSort(x));
 }
 
-module.exports = mode;
+export default mode;

--- a/src/mode_fast.js
+++ b/src/mode_fast.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 /* globals Map: false */
 
@@ -56,4 +55,4 @@ function modeFast/*::<T>*/(x /*: Array<T> */)/*: ?T */ {
     return mode;
 }
 
-module.exports = modeFast;
+export default modeFast;

--- a/src/mode_sorted.js
+++ b/src/mode_sorted.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -61,4 +60,4 @@ function modeSorted(sorted /*: Array<number> */)/*:number*/ {
     return value;
 }
 
-module.exports = modeSorted;
+export default modeSorted;

--- a/src/numeric_sort.js
+++ b/src/numeric_sort.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -28,4 +27,4 @@ function numericSort(x /*: Array<number> */) /*: Array<number> */ {
         });
 }
 
-module.exports = numericSort;
+export default numericSort;

--- a/src/perceptron.js
+++ b/src/perceptron.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -93,4 +92,4 @@ PerceptronModel.prototype.train = function(features, label) {
     return this;
 };
 
-module.exports = PerceptronModel;
+export default PerceptronModel;

--- a/src/permutations_heap.js
+++ b/src/permutations_heap.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-'use strict';
-
 /**
  * Implementation of [Heap's Algorithm](https://en.wikipedia.org/wiki/Heap%27s_algorithm)
  * for generating permutations.
@@ -46,4 +44,4 @@ function permutationsHeap/*:: <T> */(elements /*: Array<T> */)/*: Array<Array<T>
     return permutations;
 }
 
-module.exports = permutationsHeap;
+export default permutationsHeap;

--- a/src/poisson_distribution.js
+++ b/src/poisson_distribution.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var epsilon = require('./epsilon');
+import epsilon from './epsilon';
 
 /**
  * The [Poisson Distribution](http://en.wikipedia.org/wiki/Poisson_distribution)
@@ -45,4 +44,4 @@ function poissonDistribution(lambda/*: number */) /*: ?number[] */ {
     return cells;
 }
 
-module.exports = poissonDistribution;
+export default poissonDistribution;

--- a/src/probit.js
+++ b/src/probit.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var epsilon = require('./epsilon');
-var inverseErrorFunction = require('./inverse_error_function');
+import epsilon from './epsilon';
+import inverseErrorFunction from './inverse_error_function';
 
 /**
  * The [Probit](http://en.wikipedia.org/wiki/Probit)
@@ -26,4 +25,4 @@ function probit(p /*: number */)/*: number */ {
     return Math.sqrt(2) * inverseErrorFunction(2 * p - 1);
 }
 
-module.exports = probit;
+export default probit;

--- a/src/product.js
+++ b/src/product.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -20,4 +19,4 @@ function product(x/*: Array<number> */)/*: number */ {
     return value;
 }
 
-module.exports = product;
+export default product;

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var quantileSorted = require('./quantile_sorted');
-var quickselect = require('./quickselect');
+import quantileSorted from './quantile_sorted';
+import quickselect from './quickselect';
 
 /**
  * The [quantile](https://en.wikipedia.org/wiki/Quantile):
@@ -104,4 +103,4 @@ function quantileIndex(len /*: number */, p /*: number */)/*:number*/ {
     }
 }
 
-module.exports = quantile;
+export default quantile;

--- a/src/quantile_sorted.js
+++ b/src/quantile_sorted.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -40,4 +39,4 @@ function quantileSorted(x /*: Array<number> */, p /*: number */)/*:number*/ {
     }
 }
 
-module.exports = quantileSorted;
+export default quantileSorted;

--- a/src/quickselect.js
+++ b/src/quickselect.js
@@ -1,7 +1,4 @@
-'use strict';
 /* @flow */
-
-module.exports = quickselect;
 
 /**
  * Rearrange items in `arr` so that all items in `[left, k]` range are the smallest.
@@ -69,3 +66,5 @@ function swap(arr, i, j) {
     arr[i] = arr[j];
     arr[j] = tmp;
 }
+
+export default quickselect;

--- a/src/r_squared.js
+++ b/src/r_squared.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -49,4 +48,4 @@ function rSquared(x /*: Array<Array<number>> */, func /*: Function */) /*: numbe
     return 1 - err / sumOfSquares;
 }
 
-module.exports = rSquared;
+export default rSquared;

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -28,4 +27,4 @@ function rootMeanSquare(x /*: Array<number> */)/*:number*/ {
     return Math.sqrt(sumOfSquares / x.length);
 }
 
-module.exports = rootMeanSquare;
+export default rootMeanSquare;

--- a/src/sample.js
+++ b/src/sample.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var shuffle = require('./shuffle');
+import shuffle from './shuffle';
 
 /**
  * Create a [simple random sample](http://en.wikipedia.org/wiki/Simple_random_sample)
@@ -30,4 +29,4 @@ function sample/*:: <T> */(
     return shuffled.slice(0, n);
 }
 
-module.exports = sample;
+export default sample;

--- a/src/sample_correlation.js
+++ b/src/sample_correlation.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var sampleCovariance = require('./sample_covariance');
-var sampleStandardDeviation = require('./sample_standard_deviation');
+import sampleCovariance from './sample_covariance';
+import sampleStandardDeviation from './sample_standard_deviation';
 
 /**
  * The [correlation](http://en.wikipedia.org/wiki/Correlation_and_dependence) is
@@ -23,4 +22,4 @@ function sampleCorrelation(x/*: Array<number> */, y/*: Array<number> */)/*:numbe
     return cov / xstd / ystd;
 }
 
-module.exports = sampleCorrelation;
+export default sampleCorrelation;

--- a/src/sample_covariance.js
+++ b/src/sample_covariance.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
+import mean from './mean';
 
 /**
  * [Sample covariance](https://en.wikipedia.org/wiki/Sample_mean_and_sampleCovariance) of two datasets:
@@ -52,4 +51,4 @@ function sampleCovariance(x /*:Array<number>*/, y /*:Array<number>*/)/*:number*/
     return sum / besselsCorrection;
 }
 
-module.exports = sampleCovariance;
+export default sampleCovariance;

--- a/src/sample_kurtosis.js
+++ b/src/sample_kurtosis.js
@@ -1,15 +1,14 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
+import mean from './mean';
 
 /**
  * [Kurtosis](http://en.wikipedia.org/wiki/Kurtosis) is
  * a measure of the heaviness of a distribution's tails relative to its
  * variance. The kurtosis value can be positive or negative, or even undefined.
  *
- * Implementation is based on Fisher's excess kurtosis definition and uses 
- * unbiased moment estimators. This is the version found in Excel and available 
+ * Implementation is based on Fisher's excess kurtosis definition and uses
+ * unbiased moment estimators. This is the version found in Excel and available
  * in several statistical packages, including SAS and SciPy.
  *
  * @param {Array<number>} x a sample of 4 or more data points
@@ -37,8 +36,8 @@ function sampleKurtosis(x /*: Array<number> */)/*:number*/ {
         fourthCentralMoment += tempValue * tempValue * tempValue * tempValue;
     }
 
-    return (n - 1) / ((n - 2) * (n - 3)) * 
+    return (n - 1) / ((n - 2) * (n - 3)) *
         (n * (n + 1) * fourthCentralMoment / (secondCentralMoment * secondCentralMoment) - 3 * (n - 1));
 }
 
-module.exports = sampleKurtosis;
+export default sampleKurtosis;

--- a/src/sample_skewness.js
+++ b/src/sample_skewness.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
+import mean from './mean';
 
 /**
  * [Skewness](http://en.wikipedia.org/wiki/Skewness) is
@@ -51,4 +50,4 @@ function sampleSkewness(x /*: Array<number> */)/*:number*/ {
     return n * sumCubedDeviations / ((n - 1) * (n - 2) * cubedS);
 }
 
-module.exports = sampleSkewness;
+export default sampleSkewness;

--- a/src/sample_standard_deviation.js
+++ b/src/sample_standard_deviation.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var sampleVariance = require('./sample_variance');
+import sampleVariance from './sample_variance';
 
 /**
  * The [sample standard deviation](http://en.wikipedia.org/wiki/Standard_deviation#Sample_standard_deviation)
@@ -19,4 +18,4 @@ function sampleStandardDeviation(x/*:Array<number>*/)/*:number*/ {
     return Math.sqrt(sampleVarianceX);
 }
 
-module.exports = sampleStandardDeviation;
+export default sampleStandardDeviation;

--- a/src/sample_variance.js
+++ b/src/sample_variance.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var sumNthPowerDeviations = require('./sum_nth_power_deviations');
+import sumNthPowerDeviations from './sum_nth_power_deviations';
 
 /**
  * The [sample variance](https://en.wikipedia.org/wiki/Variance#Sample_variance)
@@ -37,4 +36,4 @@ function sampleVariance(x /*: Array<number> */)/*:number*/ {
     return sumSquaredDeviationsValue / besselsCorrection;
 }
 
-module.exports = sampleVariance;
+export default sampleVariance;

--- a/src/sample_with_replacement.js
+++ b/src/sample_with_replacement.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -39,4 +38,4 @@ function sampleWithReplacement/*::<T>*/(x/*:Array<T>*/,
     return sample;
 }
 
-module.exports = sampleWithReplacement;
+export default sampleWithReplacement;

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var shuffleInPlace = require('./shuffle_in_place');
+import shuffleInPlace from './shuffle_in_place';
 
 /**
  * A [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
@@ -25,4 +24,4 @@ function shuffle/*::<T>*/(x/*:Array<T>*/, randomSource/*:Function*/) {
     return shuffleInPlace(sample.slice(), randomSource);
 }
 
-module.exports = shuffle;
+export default shuffle;

--- a/src/shuffle_in_place.js
+++ b/src/shuffle_in_place.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -53,4 +52,4 @@ function shuffleInPlace(x/*:Array<any>*/, randomSource/*:Function*/)/*:Array<any
     return x;
 }
 
-module.exports = shuffleInPlace;
+export default shuffleInPlace;

--- a/src/sign.js
+++ b/src/sign.js
@@ -1,15 +1,14 @@
-'use strict';
 /* @flow */
 
 /**
- * [Sign](https://en.wikipedia.org/wiki/Sign_function) is a function 
+ * [Sign](https://en.wikipedia.org/wiki/Sign_function) is a function
  * that extracts the sign of a real number
- * 
- * @param {Number} x input value
- * @returns {Number} sign value either 1, 0 or -1
+ *
+ * @param {number} x input value
+ * @returns {number} sign value either 1, 0 or -1
  * @throws {TypeError} if the input argument x is not a number
  * @private
- * 
+ *
  * @example
  * sign(2); // => 1
  */
@@ -27,4 +26,4 @@ function sign(x/*: number */)/*: number */ {
     }
 }
 
-module.exports = sign;
+export default sign;

--- a/src/standard_deviation.js
+++ b/src/standard_deviation.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var variance = require('./variance');
+import variance from './variance';
 
 /**
  * The [standard deviation](http://en.wikipedia.org/wiki/Standard_deviation)
@@ -27,4 +26,4 @@ function standardDeviation(x /*: Array<number> */)/*:number*/ {
     return Math.sqrt(v);
 }
 
-module.exports = standardDeviation;
+export default standardDeviation;

--- a/src/standard_normal_table.js
+++ b/src/standard_normal_table.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 var SQRT_2PI = Math.sqrt(2 * Math.PI);
@@ -34,4 +33,4 @@ for (var z = 0; z <= 3.09; z += 0.01) {
     standardNormalTable.push(cumulativeDistribution(z));
 }
 
-module.exports = standardNormalTable;
+export default standardNormalTable;

--- a/src/subtract_from_mean.js
+++ b/src/subtract_from_mean.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -20,4 +19,4 @@ function subtractFromMean(mean /*: number*/, n/*: number */, value/*: number */)
     return ((mean * n) - value) / (n - 1);
 }
 
-module.exports = subtractFromMean;
+export default subtractFromMean;

--- a/src/sum.js
+++ b/src/sum.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -53,4 +52,4 @@ function sum(x/*: Array<number> */)/*: number */ {
     return sum + correction;
 }
 
-module.exports = sum;
+export default sum;

--- a/src/sum_nth_power_deviations.js
+++ b/src/sum_nth_power_deviations.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
+import mean from './mean';
 
 /**
  * The sum of deviations to the Nth power.
@@ -40,4 +39,4 @@ function sumNthPowerDeviations(x/*: Array<number> */, n/*: number */)/*:number*/
     return sum;
 }
 
-module.exports = sumNthPowerDeviations;
+export default sumNthPowerDeviations;

--- a/src/sum_simple.js
+++ b/src/sum_simple.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -20,4 +19,4 @@ function sumSimple(x/*: Array<number> */)/*: number */ {
     return value;
 }
 
-module.exports = sumSimple;
+export default sumSimple;

--- a/src/t_test.js
+++ b/src/t_test.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var standardDeviation = require('./standard_deviation');
-var mean = require('./mean');
+import mean from './mean';
+import standardDeviation from './standard_deviation';
 
 /**
  * This is to compute [a one-sample t-test](https://en.wikipedia.org/wiki/Student%27s_t-test#One-sample_t-test), comparing the mean
@@ -35,4 +34,4 @@ function tTest(x/*: Array<number> */, expectedValue/*: number */)/*:number*/ {
     return (sampleMean - expectedValue) / (sd / rootN);
 }
 
-module.exports = tTest;
+export default tTest;

--- a/src/t_test_two_sample.js
+++ b/src/t_test_two_sample.js
@@ -1,8 +1,7 @@
-'use strict';
 /* @flow */
 
-var mean = require('./mean');
-var sampleVariance = require('./sample_variance');
+import mean from './mean';
+import sampleVariance from './sample_variance';
 
 /**
  * This is to compute [two sample t-test](http://en.wikipedia.org/wiki/Student's_t-test).
@@ -63,4 +62,4 @@ function tTestTwoSample(
     }
 }
 
-module.exports = tTestTwoSample;
+export default tTestTwoSample;

--- a/src/unique_count_sorted.js
+++ b/src/unique_count_sorted.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -27,4 +26,4 @@ function uniqueCountSorted(x/*: Array<any>*/)/*: number */ {
     return uniqueValueCount;
 }
 
-module.exports = uniqueCountSorted;
+export default uniqueCountSorted;

--- a/src/variance.js
+++ b/src/variance.js
@@ -1,7 +1,6 @@
-'use strict';
 /* @flow */
 
-var sumNthPowerDeviations = require('./sum_nth_power_deviations');
+import sumNthPowerDeviations from './sum_nth_power_deviations';
 
 /**
  * The [variance](http://en.wikipedia.org/wiki/Variance)
@@ -28,4 +27,4 @@ function variance(x/*: Array<number> */)/*:number*/ {
     return sumNthPowerDeviations(x, 2) / x.length;
 }
 
-module.exports = variance;
+export default variance;

--- a/src/z_score.js
+++ b/src/z_score.js
@@ -1,4 +1,3 @@
-'use strict';
 /* @flow */
 
 /**
@@ -28,4 +27,4 @@ function zScore(x/*:number*/, mean/*:number*/, standardDeviation/*:number*/)/*:n
     return (x - mean) / standardDeviation;
 }
 
-module.exports = zScore;
+export default zScore;

--- a/test/add_to_mean.test.js
+++ b/test/add_to_mean.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -1,7 +1,7 @@
 /* eslint no-shadow: 0 */
-'use strict';
 
-var BayesianClassifier = require('../src/bayesian_classifier');
+
+var BayesianClassifier = require('../').BayesianClassifier;
 var test = require('tap').test;
 
 test('BayesianClassifier', function(t) {

--- a/test/bernoulli_distribution.test.js
+++ b/test/bernoulli_distribution.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/binomial_distribution.test.js
+++ b/test/binomial_distribution.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/bisect.test.js
+++ b/test/bisect.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var bisect = require('../src/bisect');
+var bisect = require('../').bisect;
 
 test('bisect', function(t) {
     t.test('can find root of sin and cos', function(t) {

--- a/test/chi_squared_goodness_of_fit.test.js
+++ b/test/chi_squared_goodness_of_fit.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/chunk.test.js
+++ b/test/chunk.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/ckmeans.test.js
+++ b/test/ckmeans.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var cK = require('../src/ckmeans');
+var cK = require('../').ckmeans;
 
 test('C k-means', function(t) {
     t.ok(cK, 'exports fn');

--- a/test/combinations.test.js
+++ b/test/combinations.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/combinations_replacement.test.js
+++ b/test/combinations_replacement.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/combine_means.js
+++ b/test/combine_means.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/combine_variances.js
+++ b/test/combine_variances.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/cumulative.js
+++ b/test/cumulative.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/equal_interval_breaks.test.js
+++ b/test/equal_interval_breaks.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var equalIntervalBreaks = require('../src/equal_interval_breaks');
+var equalIntervalBreaks = require('../').equalIntervalBreaks;
 
 test('equalIntervalBreaks', function(t) {
     t.deepEqual(equalIntervalBreaks([1], 4), [1], '1-length case');

--- a/test/error_function.js
+++ b/test/error_function.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/factorial.test.js
+++ b/test/factorial.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/geometric_mean.test.js
+++ b/test/geometric_mean.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/harmonic_mean.test.js
+++ b/test/harmonic_mean.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/iqr.test.js
+++ b/test/iqr.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/kernel_density_estimation.test.js
+++ b/test/kernel_density_estimation.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/linear_regression.test.js
+++ b/test/linear_regression.test.js
@@ -1,9 +1,9 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var linearRegression = require('../src/linear_regression');
-var linearRegressionLine = require('../src/linear_regression_line');
+var linearRegression = require('../').linearRegression;
+var linearRegressionLine = require('../').linearRegressionLine;
 
 test('linear regression', function(t) {
     t.test('correctly generates a line for a 0, 0 to 1, 1 dataset', function(t) {

--- a/test/mad.test.js
+++ b/test/mad.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/mean.test.js
+++ b/test/mean.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/median.test.js
+++ b/test/median.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/minmax.test.js
+++ b/test/minmax.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/mode.test.js
+++ b/test/mode.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/normal_distribution.test.js
+++ b/test/normal_distribution.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/numeric_sort.test.js
+++ b/test/numeric_sort.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var numericSort = require('../src/numeric_sort');
+var numericSort = require('../').numericSort;
 
 test('numericSort', function(t) {
     t.deepEqual(numericSort([1, 2]), [1, 2]);

--- a/test/perceptron.test.js
+++ b/test/perceptron.test.js
@@ -1,7 +1,7 @@
 /* eslint no-shadow: 0 */
-'use strict';
 
-var PerceptronModel = require('../src/perceptron');
+
+var PerceptronModel = require('../').PerceptronModel;
 var test = require('tap').test;
 
 test('perceptron', function(t) {

--- a/test/permutations_heap.js
+++ b/test/permutations_heap.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/poisson_distribution.test.js
+++ b/test/poisson_distribution.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/quantile.test.js
+++ b/test/quantile.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/quantilesorted.test.js
+++ b/test/quantilesorted.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/quickselect.test.js
+++ b/test/quickselect.test.js
@@ -1,7 +1,7 @@
-'use strict';
+
 
 var test = require('tap').test;
-var quickselect = require('../src/quickselect');
+var quickselect = require('../').quickselect;
 
 test('quickselect', function (t) {
     var arr = [65, 28, 59, 33, 21, 56, 22, 95, 50, 12, 90, 53, 28, 77, 39];

--- a/test/r_squared.test.js
+++ b/test/r_squared.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/root_mean_square.test.js
+++ b/test/root_mean_square.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var Random = require('random-js');

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_covariance.test.js
+++ b/test/sample_covariance.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_kurtosis.test.js
+++ b/test/sample_kurtosis.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_skewness.test.js
+++ b/test/sample_skewness.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_standard_deviation.test.js
+++ b/test/sample_standard_deviation.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_variance.test.js
+++ b/test/sample_variance.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sample_with_replacement.test.js
+++ b/test/sample_with_replacement.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var Random = require('random-js');

--- a/test/shuffle.test.js
+++ b/test/shuffle.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var Random = require('random-js');

--- a/test/sign.test.js
+++ b/test/sign.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var sign = require('../src/sign');
+var sign = require('../').sign;
 
 test('bisect', function(t) {
     t.test('can find sign of number', function(t) {

--- a/test/standard_deviation.test.js
+++ b/test/standard_deviation.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/standard_normal_table.js
+++ b/test/standard_normal_table.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/subtract_from_mean.js
+++ b/test/subtract_from_mean.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sum.test.js
+++ b/test/sum.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/sum_nth_power_deviations.test.js
+++ b/test/sum_nth_power_deviations.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/t_test.test.js
+++ b/test/t_test.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test,
     ss = require('../');

--- a/test/t_test_two_sample.test.js
+++ b/test/t_test_two_sample.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test,
     ss = require('../');

--- a/test/unique_count_sorted.test.js
+++ b/test/unique_count_sorted.test.js
@@ -1,8 +1,8 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
-var uniqueCountSorted = require('../src/unique_count_sorted');
+var uniqueCountSorted = require('../').uniqueCountSorted;
 
 test('uniqueCountSorted', function(t) {
     t.equal(uniqueCountSorted([]), 0);

--- a/test/variance.test.js
+++ b/test/variance.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');

--- a/test/z_score.test.js
+++ b/test/z_score.test.js
@@ -1,5 +1,5 @@
 /* eslint no-shadow: 0 */
-'use strict';
+
 
 var test = require('tap').test;
 var ss = require('../');


### PR DESCRIPTION
## Implementation of ES6 modules 💥 🎉 

Ref: https://github.com/simple-statistics/simple-statistics/issues/210

- [x] Include Rollup configuration to `dist/simple-statistics.js`
- [x] Add source mapping & minify directly in Rollup config (1.5s to build Rollup bundle)
- [x] Documentation JSDocs test
- [x] Replaced Browserify + minify with Rollup
- [x] Convert all source code to ES6 export/import
- [x] Convert tests to use main library `var ss = require('../')`
- [x] Dropped `"use strict"` (unnecessary inside of modules)
- [x] Fix JSDocs linting issues
- [x] Dropped `.npmignore` (not required if you include `files` in `package.json`)

Tons of changes, but it's really not too bad to review, I've made sure to only change what's needed to make the ES6 module implementation.

Rollup config & module export syntax was inspired by @mbostock's [`d3-geo-projection`](https://github.com/d3/d3-geo-projection).

CC: @mourner @tmcw