### PR TITLE
feat: standardError

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ export { default as ckmeans } from "./src/ckmeans";
 export { default as uniqueCountSorted } from "./src/unique_count_sorted";
 export { default as sumNthPowerDeviations } from "./src/sum_nth_power_deviations";
 export { default as equalIntervalBreaks } from "./src/equal_interval_breaks";
+export { default as standardError } from "./src/standard_error";
 
 // sample statistics
 export { default as sampleCovariance } from "./src/sample_covariance";

--- a/src/standard_error.js
+++ b/src/standard_error.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+import standardDeviation from './standard_deviation';
+
+/**
+ * The [standard error](https://en.wikipedia.org/wiki/Standard_error)
+ * of a statistic (here the mean) is the standard deviation of its sampling
+ * distribution or sometimes an estimate of that standard deviation.
+ *
+ * @param {Array<number>} x input
+ * @returns {number} standard error
+ * @example
+ * standardError([2, 4, 4, 4, 5, 5, 7, 9]); // => 2 / Math.sqrt(8)
+ */
+function standardError(x /*: Array<number> */)/*:number*/ {
+    if (x.length === 1) {
+        return 0;
+    }
+
+    var std = standardDeviation(x);
+
+    return std / Math.sqrt(x.length);
+}
+
+export default standardError;

--- a/src/standard_error.js
+++ b/src/standard_error.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import standardDeviation from './standard_deviation';
+import standardDeviation from "./standard_deviation";
 
 /**
  * The [standard error](https://en.wikipedia.org/wiki/Standard_error)
@@ -8,18 +8,17 @@ import standardDeviation from './standard_deviation';
  * distribution or sometimes an estimate of that standard deviation.
  *
  * @param {Array<number>} x input
+ * @throws {Error} if x has is an empty array
  * @returns {number} standard error
  * @example
  * standardError([2, 4, 4, 4, 5, 5, 7, 9]); // => 2 / Math.sqrt(8)
  */
-function standardError(x /*: Array<number> */)/*:number*/ {
-    if (x.length === 1) {
-        return 0;
+function standardError(x /*: Array<number> */) /*:number*/ {
+    if (x.length === 0) {
+        throw new Error("standardError is not defined for empty arrays");
     }
 
-    var std = standardDeviation(x);
-
-    return std / Math.sqrt(x.length);
+    return standardDeviation(x) / Math.sqrt(x.length);
 }
 
 export default standardError;

--- a/test/standard-error.test.js
+++ b/test/standard-error.test.js
@@ -1,12 +1,29 @@
 /* eslint no-shadow: 0 */
 
+const test = require("tap").test;
+const ss = require("../");
 
-var test = require('tap').test;
-var ss = require('../');
+test("standardError", function (t) {
+    t.test(
+        "can get the standard error of the wikipedia standard deviation example",
+        function (t) {
+            t.equal(
+                ss.standardError([2, 4, 4, 4, 5, 5, 7, 9]),
+                2 / Math.sqrt(8)
+            );
+            t.end();
+        }
+    );
 
-test('standardError', function(t) {
-    t.test('can get the standard error of the wikipedia standard deviation example', function(t) {
-        t.equal(ss.standardError([2, 4, 4, 4, 5, 5, 7, 9]), 2 / Math.sqrt(8));
+    t.test("is zero for single-element arrays", function (t) {
+        t.equal(ss.standardError([42]), 0);
+        t.end();
+    });
+
+    t.test("is not defined for empty arrays", function (t) {
+        t.throws(function () {
+            ss.standardError([]);
+        }, "standardError is not defined for empty arrays");
         t.end();
     });
 

--- a/test/standard-error.test.js
+++ b/test/standard-error.test.js
@@ -1,0 +1,14 @@
+/* eslint no-shadow: 0 */
+
+
+var test = require('tap').test;
+var ss = require('../');
+
+test('standardError', function(t) {
+    t.test('can get the standard error of the wikipedia standard deviation example', function(t) {
+        t.equal(ss.standardError([2, 4, 4, 4, 5, 5, 7, 9]), 2 / Math.sqrt(8));
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Adding the `standardError` function to the library.

Some interrogations:

* What should we return when the list has only 1 element? `0` as done now?
* What should we do with an empty list? Throw? (Note that this case is not addressed with the `standardDeviation` function either).
* Should we also add `sampleStandardError` with Bessel's correction?

Note that I can add some unit tests to reflect our choices on the first two questions.