### PR TITLE
new feature: permutation test

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,9 @@ export { default as errorFunction, default as erf } from './src/error_function';
 export { default as inverseErrorFunction } from './src/inverse_error_function';
 export { default as probit } from './src/probit';
 
+// Non-parametric Methods
+export { default as permutationTest } from './src/permutation_test';
+
 // Root-finding methods
 export { default as bisect } from './src/bisect';
 

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -27,13 +27,20 @@ import shuffleInPlace from './shuffle_in_place';
 function permutationTest(
     sampleX/*: Array<number> */,
     sampleY/*: Array<number> */,
-    alternative/*: string */ = 'two_side',
-    k/*: number */ = 10000)/*: ?number */ {
+    alternative/*: string */,
+    k/*: number */)/*: ?number */ {
+    // Set default arguments
+    if (k === undefined) {
+        k = 10000;
+    }
+    if (alternative === undefined) {
+        alternative = 'two_side';
+    }
     if (alternative !== 'two_side' && alternative !== 'greater' && alternative !== 'less') {
-        throw new Error('`alternative` must be either \'two_tail\', \'greater\', or \'less\'');
+        throw new Error('`alternative` must be either \'two_side\', \'greater\', or \'less\'');
     }
 
-    // int pValue var
+    // init pValue
     var pValue;
 
     // get means for each sample

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -65,23 +65,33 @@ function permutationTest(
         testStatDsn[i] = permTestStatistic;
     }
 
-    // Calculate p-value depending on alternative 
-    // more info on p-value calculations: https://onlinecourses.science.psu.edu/stat464/node/35
+    // Calculate p-value depending on alternative
+    // For this test, we calculate the percentage of 'extreme' test statistics (subject to our hypothesis)
+    // more info on permutation test p-value calculations: https://onlinecourses.science.psu.edu/stat464/node/35
+    var numExtremeTStats = 0;
     if (alternative === 'two_side') {
-        pValue = sum(testStatDsn.map(function(tStat) {
-            return +(Math.abs(tStat) >= Math.abs(testStatistic));
-        })) / k;
+        for (i = 0; i <= k; i++) {
+            if (Math.abs(testStatDsn[i]) >= Math.abs(testStatistic)) {
+                numExtremeTStats += 1;
+            }
+        }
     } else if (alternative === 'greater') {
-        pValue = sum(testStatDsn.map(function(tStat) {
-            return +(tStat >= testStatistic);
-        })) / k;
+        for (i = 0; i <= k; i++) {
+            if (testStatDsn[i] >= testStatistic) {
+                numExtremeTStats += 1;
+            }
+        }
     } else { // alternative === 'less'
-        pValue = sum(testStatDsn.map(function(tStat) {
-            return +(tStat <= testStatistic);
-        })) / k;
+        for (i = 0; i <= k; i++) {
+            if (testStatDsn[i] <= testStatistic) {
+                numExtremeTStats += 1;
+            }
+        }
     }
+
+    pValue = numExtremeTStats / k;
             
-    return pValue
+    return pValue;
         
 }
 

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -1,0 +1,85 @@
+/* @flow */
+
+import mean from './mean';
+import shuffle from './shuffle';
+import sum from './sum';
+
+/**
+ * Conducts a [permutation test](https://en.wikipedia.org/wiki/Resampling_(statistics)#Permutation_tests)
+ * to determine if two data sets are *significantly* different from each other, using
+ * the difference of means between the groups as the test statistic. 
+ * The function allows for the following hypotheses:
+ * - two_tail = Null hypothesis: the two distributions are equal.
+ * - greater = Null hypothesis: observations from sampleX tend to be smaller than those from sampleY.
+ * - less = Null hypothesis: observations from sampleX tend to be greater than those from sampleY.
+ * [Learn more about one-tail vs two-tail tests.](https://en.wikipedia.org/wiki/One-_and_two-tailed_tests)
+ *
+ * @param {Array<number>} sampleX first dataset (e.g. treatment data)
+ * @param {Array<number>} sampleY second dataset (e.g. control data)
+ * @param {string} alternative alternative hypothesis, either 'two_sided' (default), 'greater', or 'less'
+ * @param {number} k number of values in permutation distribution. 
+ * @returns {number} p-value The probability of observing the difference between groups (as or more extreme than what we did), assuming the null hypothesis.
+ *
+ * @example
+ * var control = [2, 5, 3, 6, 7, 2, 5];
+ * var treatment = [20, 5, 13, 12, 7, 2, 2];
+ * permutationTest(control, treatment); // ~0.1324 
+ */
+function permutationTest(
+    sampleX/*: Array<number> */,
+    sampleY/*: Array<number> */,
+    alternative/*: string */ = 'two_side',
+    k/*: number */ = 10000)/*: ?number */ {
+    if (alternative !== 'two_side' && alternative !== 'greater' && alternative !== 'less') {
+        throw new Error('`alternative` must be either \'two_tail\', \'greater\', or \'less\'');
+    }
+
+    // get means for each sample
+    var meanX = mean(sampleX);
+    var meanY = mean(sampleY);
+    // int pValue var
+    var pValue;
+    
+    // calculate initial test statistic. This will be our point of comparison with
+    // the generated test statistics.
+    var testStatistic = meanX - meanY;
+    
+    // create test-statistic distribution
+    var testStatDsn = new Array(k);
+    
+    for (var i = 0; i < k; i++) {
+        
+        // 1. shuffle data assignments
+        var allData = sampleX.concat(sampleY);
+        var permData = shuffle(allData);
+        var permLeft = permData.splice(0, Math.floor(permData.length / 2));
+        var permRight = permData;
+    
+        // 2.re-calculate test statistic
+        var permTestStatistic = mean(permLeft) - mean(permRight);
+
+        // 3. store test statistic to build test statistic distribution
+        testStatDsn[i] = permTestStatistic;
+    }
+
+    // Calculate p-value depending on alternative 
+    // more info on p-value calculations: https://onlinecourses.science.psu.edu/stat464/node/35
+    if (alternative === 'two_side') {
+        pValue = sum(testStatDsn.map(function(tStat) {
+            return +(Math.abs(tStat) >= Math.abs(testStatistic));
+        })) / k;
+    } else if (alternative === 'greater') {
+        pValue = sum(testStatDsn.map(function(tStat) {
+            return +(tStat >= testStatistic);
+        })) / k;
+    } else { // alternative === 'less'
+        pValue = sum(testStatDsn.map(function(tStat) {
+            return +(tStat <= testStatistic);
+        })) / k;
+    }
+            
+    return pValue
+        
+}
+
+export default permutationTest;

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -34,27 +34,31 @@ function permutationTest(
         throw new Error('`alternative` must be either \'two_tail\', \'greater\', or \'less\'');
     }
 
+    // int pValue var
+    var pValue;
+
     // get means for each sample
     var meanX = mean(sampleX);
     var meanY = mean(sampleY);
-    // int pValue var
-    var pValue;
-    
+
     // calculate initial test statistic. This will be our point of comparison with
     // the generated test statistics.
     var testStatistic = meanX - meanY;
-    
+
     // create test-statistic distribution
     var testStatDsn = new Array(k);
+    
+    // combine datsets so we can easily shuffle later
+    var allData = sampleX.concat(sampleY);
+    var midArray = Math.floor(allData.length / 2);
     
     for (var i = 0; i < k; i++) {
         
         // 1. shuffle data assignments
-        var allData = sampleX.concat(sampleY);
-        var permData = shuffle(allData);
-        var permLeft = permData.splice(0, Math.floor(permData.length / 2));
-        var permRight = permData;
-    
+        allData = shuffle(allData);
+        var permLeft = allData.slice(0, midArray);
+        var permRight = allData.slice(midArray, allData.length);
+
         // 2.re-calculate test statistic
         var permTestStatistic = mean(permLeft) - mean(permRight);
 

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -50,14 +50,14 @@ function permutationTest(
     
     // combine datsets so we can easily shuffle later
     var allData = sampleX.concat(sampleY);
-    var midArray = Math.floor(allData.length / 2);
+    var midIndex = Math.floor(allData.length / 2);
     
     for (var i = 0; i < k; i++) {
         
         // 1. shuffle data assignments
         allData = shuffle(allData);
-        var permLeft = allData.slice(0, midArray);
-        var permRight = allData.slice(midArray, allData.length);
+        var permLeft = allData.slice(0, midIndex);
+        var permRight = allData.slice(midIndex, allData.length);
 
         // 2.re-calculate test statistic
         var permTestStatistic = mean(permLeft) - mean(permRight);

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 import mean from './mean';
-import shuffle from './shuffle';
-import sum from './sum';
+import shuffleInPlace from './shuffle_in_place';
 
 /**
  * Conducts a [permutation test](https://en.wikipedia.org/wiki/Resampling_(statistics)#Permutation_tests)
@@ -55,7 +54,7 @@ function permutationTest(
     for (var i = 0; i < k; i++) {
         
         // 1. shuffle data assignments
-        allData = shuffle(allData);
+        shuffleInPlace(allData);
         var permLeft = allData.slice(0, midIndex);
         var permRight = allData.slice(midIndex, allData.length);
 

--- a/test/permutation_test.test.js
+++ b/test/permutation_test.test.js
@@ -1,0 +1,31 @@
+/* eslint no-shadow: 0 */
+
+
+var test = require('tap').test,
+    ss = require('../');
+
+test('permutation test', function(t) {
+
+    t.test('P-value of identical distributions being different should be 1', function(t) {
+        t.equal(ss.permutationTest([2, 2, 2, 2, 2], [2, 2, 2, 2, 2]), 1);
+        t.end();
+    });
+    t.test('P-value of distribution less than itself should be 1', function(t) {
+        t.equal(ss.permutationTest([2, 2, 2, 2, 2], [2, 2, 2, 2, 2], 'greater'), 1);
+        t.end();
+    });
+    t.test('P-value of small sample greater than large sample should be 0', function(t) {
+        t.equal(ss.permutationTest([1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [99999, 99999, 99999, 99999, 99999, 99999, 99999, 99999, 99999, 99999],
+            'less'), 0);
+        t.end();
+    });
+    t.test('permutationTest should throw error if wrong argument received', function(t) {
+        t.throws(function () {
+            ss.permutationTest([1, 69, 420], [42, 42, 42], 'one-tailed');
+        }, 'alternative must be one of specified options');
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Hello everyone -

Here's an implementation of `permutation_test` (see issue #271 ); hopefully the first of many statistical tests to be added :)

I opted for the `alternative` argument as opposed to `null` because that's congruent with the APIs for similar `R` functions (e.g. `coin::independence_test`, `t.test`, `wilcox.test`), so I figured I'd keep it.






