### PR TITLE
Try using --jobs=4 to make tap test runs faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "release": "standard-version && sh ./scripts/update_website.sh",
     "pretest": "npm run build",
-    "test": "npm run lint && tap --coverage test/*.test.js && npm run jsdoctest",
+    "test": "npm run lint && tap --coverage test/*.test.js --jobs=4 && npm run jsdoctest",
     "build": "rm -rf dist && mkdir dist && rollup -c",
     "prepublish": "npm run build && ./scripts/update_readme.js",
     "prelint": "are-we-flow-yet src && flow check src && tsc",


### PR DESCRIPTION
This makes tests about 2x faster on my computer, but no big change on CircleCI, which I think is fine - there's no notable decrease of performance on Circle either.