### PR TITLE
new feat: gammaln

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ export { default as PerceptronModel, default as perceptron } from './src/percept
 export { default as epsilon } from './src/epsilon'; // We make ε available to the test suite.
 export { default as factorial } from './src/factorial';
 export { default as gamma } from './src/gamma';
+export { default as gammaln } from './src/gammaln';
 export { default as bernoulliDistribution } from './src/bernoulli_distribution';
 export { default as binomialDistribution } from './src/binomial_distribution';
 export { default as poissonDistribution } from './src/poisson_distribution';

--- a/src/gammaln.js
+++ b/src/gammaln.js
@@ -1,0 +1,58 @@
+/* @flow */
+
+/**
+ * Compute the logarithm of the [gamma function](https://en.wikipedia.org/wiki/Gamma_function) of a value using Lanczos' approximation.
+ * This function takes as input any real-value n greater than 0.
+ * This function is useful for values of n too large for the normal gamma function (n > 165).
+ * The code is based on Lanczo's Gamma approximation, defined [here](http://my.fit.edu/~gabdo/gamma.txt).
+ *
+ * @param {number} n Any real number greater than zero.
+ * @returns {number} The logaritm of gamma of the input value.
+ *
+ * @example
+ * gammaln(500); // 2605.1158503617335
+ * gammaln(2.4); // 0.21685932244884043 
+ */
+function gammaln(n /*: number */ ) /*: number */ {
+
+    // Return infinity if value not in domain
+    if (n <= 0) {
+        return Infinity;
+    }
+    
+    // Decrement n, because approximation is defined for n - 1
+    n--;
+    
+    // Define series coefficients
+    var coefficients = [
+        0.99999999999999709182,
+        57.156235665862923517,
+        -59.597960355475491248,
+        14.136097974741747174,
+        -0.49191381609762019978,
+        0.33994649984811888699e-4,
+        0.46523628927048575665e-4,
+        -0.98374475304879564677e-4,
+        0.15808870322491248884e-3,
+        -0.21026444172410488319e-3,
+        0.21743961811521264320e-3,
+        -0.16431810653676389022e-3,
+        0.84418223983852743293e-4,
+        -0.26190838401581408670e-4,
+        0.36899182659531622704e-5
+    ];
+    
+    // Create series approximation
+    var a = coefficients[0];
+    
+    for (var i = 1; i < 15; i++) {
+        a += coefficients[i] / (n + i);
+    }
+    
+    var g = (607 / 128) + (1 / 2) + n;
+    
+    // Return natural logarithm of gamma(n)
+    return (Math.log(Math.sqrt(2 * Math.PI)) + Math.log(a)) + (n + (1 / 2)) * Math.log(g) - g;
+}
+
+export default gammaln;

--- a/test/gammaln.test.js
+++ b/test/gammaln.test.js
@@ -1,0 +1,27 @@
+/* eslint no-shadow: 0 */
+
+
+var test = require('tap').test,
+    ss = require('../');
+
+test('gammaln', function(t) {
+
+    t.test('gammaln for positive real float should be correct', function(t) {
+        t.equal(ss.gammaln(11.54), 16.388002631263966);
+        t.end();
+    });
+    t.test('exp(gammaln(n)) for n should equal gamma(n)', function(t) {
+        t.equal(Math.round(Math.exp(ss.gammaln(8.2))), Math.round(ss.gamma(8.2)));
+        t.end();
+    });
+    t.test('gammaln for negative n should be Infinity', function(t) {
+        t.equal(ss.gammaln(-42.5), Infinity);
+        t.end();
+    });
+    t.test('gammaln for n === 0 should return NaN', function(t) {
+        t.equal(ss.gammaln(0), Infinity);
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Hey all,

Here's an implementation of the log-gamma function, defined for positive input. It may seem redundant, but it's pretty common to have both a `gamma` and `gammaln` function defined (e.g., `lgamma` in R, `scipy.special.gammaln` in python). `gamma` has a fairly limited domain (`n~170`), and one way around this is to take the exponent of log-gamma (e.g. beta distribution). 

My implementation is based on [this](http://my.fit.edu/~gabdo/gamma.txt), which is the basis of the [apache commons](http://commons.apache.org/proper/commons-math/) `logGamma` function.


Value comparisons between my implementation and R's `base::lgamma`:


| n       | gammaln (js)         | lgamma (R) | scipy.special.gammaln (python) |
|---------|----------------------|------------|------------|
| 1.5     | -0.12078223763524498 | -0.1207822 |  -0.12078223763524526 |
| 150     | 600.0094705553273    | 600.0095   | 600.0094705553274  |
| 24.1234 | 51.99658210360424    | 51.99658   | 51.99658210360425 |
| 300.4   | 1411.4831804160076   | 1411.483   | 1411.4831804160074 |
