### PR TITLE
build(package): Add unpkg field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "main": "dist/simple-statistics.js",
   "module": "dist/simple-statistics.mjs",
   "browser": "dist/simple-statistics.min.js",
+  "unpkg": "dist/simple-statistics.min.js",
   "types": "index.d.ts",
   "engines": {
     "node": "*"


### PR DESCRIPTION
unpkg.com, a NPM CDN, uses an unpkg field, then the browser field (undocumented), and then the main field to find a package's entry point. By adding the unpkg field, simple-statistics will only rely on unpkg's documented behavior.

References d3-require: https://github.com/d3/d3-require/issues/12