### PR TITLE
docs(readme): Close script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
     * When you use simple-statistics from a script tag, you don't get to choose
       the variable name it is assigned to: simple-statistics will always become
       available globally as the variable `ss`. You can reassign this variable to
-      another name if you want to, but doing so is optional. <pre><script src='https://unpkg.com/simple-statistics@6.1.1/dist/simple-statistics.min.js' /></pre>
+      another name if you want to, but doing so is optional.
+      ```HTML
+      <script src='https://unpkg.com/simple-statistics@6.1.1/dist/simple-statistics.min.js'>
+      </script>
+      ```
       * `https://unpkg.com/simple-statistics@6.1.1/dist/simple-statistics.min.js`
   * **I want to use ES6 modules in a browser and I'm [willing to only support new browsers](https://caniuse.com/#feat=es6-module) to do it**
     * This module works great with the [`?module`](https://unpkg.com/#/query-parameters) query parameter of unpkg. If you

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
       <script src='https://unpkg.com/simple-statistics@6.1.1/dist/simple-statistics.min.js'>
       </script>
       ```
-      * `https://unpkg.com/simple-statistics@6.1.1/dist/simple-statistics.min.js`
   * **I want to use ES6 modules in a browser and I'm [willing to only support new browsers](https://caniuse.com/#feat=es6-module) to do it**
     * This module works great with the [`?module`](https://unpkg.com/#/query-parameters) query parameter of unpkg. If you
       specify `type='module'` in your script tag, you'll be able to import simple-statistics


### PR DESCRIPTION
In HTML5, `<script>` is not a [void element](https://www.w3.org/TR/html5/syntax.html#void-elements) and therefore needs to be closed, otherwise it "eats" whatever comes after it (until `</script>` is encountered).

This might not apply to [XML-serialized HTML5](https://mathiasbynens.be/notes/xhtml5), but I don't know anyone who uses that.

Note that even for void elements, trailing slashes are [not recommended](http://codeguide.co/#html-syntax). Presumably because they are optional, and because they [lead people to believe](https://xkcd.com/386/) that normal elements can also be self-closed.

See also: Angular[JS] https://github.com/angular/angular.js/issues/1953 / https://github.com/angular/angular/issues/5563

The closing tag is on a new line, because otherwise GitHub adds an ugly horizontal scroll bar to the code block.

The second commit removes a leftover from 3195e70a0d87.