### PR TITLE
add missing typings for extent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export { default as modeFast } from './src/mode_fast';
 export { default as modeSorted } from './src/mode_sorted';
 export { default as min } from './src/min';
 export { default as max } from './src/max';
+export { default as extent } from './src/extent';
 export { default as minSorted } from './src/min_sorted';
 export { default as maxSorted } from './src/max_sorted';
 export { default as sum } from './src/sum';

--- a/src/extent.d.ts
+++ b/src/extent.d.ts
@@ -1,5 +1,5 @@
 /**
- * https://simplestatistics.org/docs/#max
+ * https://simplestatistics.org/docs/#extent
  */
 declare function extent(
     x: number[]

--- a/src/extent.d.ts
+++ b/src/extent.d.ts
@@ -1,0 +1,8 @@
+/**
+ * https://simplestatistics.org/docs/#max
+ */
+declare function extent(
+    x: number[]
+): [number,number]
+
+export default extent;


### PR DESCRIPTION
It appears the typings for extent are not currently being exported ( extent itself is), this adds the types file for extent, and adds it to the index.d.ts exports