### PR TITLE
build: Node v13 import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
       available globally as the variable `ss`. You can reassign this variable to
       another name if you want to, but doing so is optional.
       ```HTML
-      <script src='https://unpkg.com/simple-statistics@7.0.8/dist/simple-statistics.min.js'>
+      <script src='https://unpkg.com/simple-statistics@7.0.9-alpha.0/dist/simple-statistics.min.js'>
       </script>
       ```
   * **I want to use ES6 modules in a browser and I'm [willing to only support new browsers](https://caniuse.com/#feat=es6-module) to do it**
@@ -45,7 +45,7 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
       directly - through `index.js` and with true [ES6 import syntax and behavior](http://exploringjs.com/es6/ch_modules.html).
       ```js
       <script type='module'>
-      import {min} from "https://unpkg.com/simple-statistics@7.0.8/index.js?module"
+      import {min} from "https://unpkg.com/simple-statistics@7.0.9-alpha.0/index.js?module"
       console.log(min([1, 2, 3]))
       </script>
       ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
       available globally as the variable `ss`. You can reassign this variable to
       another name if you want to, but doing so is optional.
       ```HTML
-      <script src='https://unpkg.com/simple-statistics@7.0.9-alpha.0/dist/simple-statistics.min.js'>
+      <script src='https://unpkg.com/simple-statistics@7.0.8/dist/simple-statistics.min.js'>
       </script>
       ```
   * **I want to use ES6 modules in a browser and I'm [willing to only support new browsers](https://caniuse.com/#feat=es6-module) to do it**
@@ -45,7 +45,7 @@ in all modern browsers (including IE) as well as in [node.js](https://nodejs.org
       directly - through `index.js` and with true [ES6 import syntax and behavior](http://exploringjs.com/es6/ch_modules.html).
       ```js
       <script type='module'>
-      import {min} from "https://unpkg.com/simple-statistics@7.0.9-alpha.0/index.js?module"
+      import {min} from "https://unpkg.com/simple-statistics@7.0.8/index.js?module"
       console.log(min([1, 2, 3]))
       </script>
       ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-statistics",
-  "version": "7.0.8",
+  "version": "7.0.9-alpha.0",
   "description": "Simple Statistics",
   "author": "Tom MacWright <tom@macwright.org> (http://macwright.org/)",
   "repository": {
@@ -44,8 +44,8 @@
   "unpkg": "dist/simple-statistics.min.js",
   "types": "index.d.ts",
   "exports": {
-    "import": "dist/simple-statistics.mjs",
-    "require": "dist/simple-statistics.js"
+    "import": "./dist/simple-statistics.mjs",
+    "require": "./dist/simple-statistics.js"
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
   "browser": "dist/simple-statistics.min.js",
   "unpkg": "dist/simple-statistics.min.js",
   "types": "index.d.ts",
+  "exports": {
+    "import": "dist/simple-statistics.mjs",
+    "require": "dist/simple-statistics.js"
+  },
   "engines": {
     "node": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-statistics",
-  "version": "7.0.9-alpha.0",
+  "version": "7.0.8",
   "description": "Simple Statistics",
   "author": "Tom MacWright <tom@macwright.org> (http://macwright.org/)",
   "repository": {


### PR DESCRIPTION
Node 13 includes another way to include modules. This is terrible, the only way to explain a modern package.json is with excuses.