### PR TITLE
Simple mean

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,12 @@ export { default as combineVariances } from "./src/combine_variances";
 export { default as geometricMean } from "./src/geometric_mean";
 export { default as harmonicMean } from "./src/harmonic_mean";
 export { default as average, default as mean } from "./src/mean";
+
+export {
+    default as averageSimple,
+    default as meanSimple
+} from "./src/mean_simple";
+
 export { default as median } from "./src/median";
 export { default as medianSorted } from "./src/median_sorted";
 export { default as subtractFromMean } from "./src/subtract_from_mean";

--- a/src/mean_simple.d.ts
+++ b/src/mean_simple.d.ts
@@ -1,0 +1,8 @@
+/**
+ * https://simplestatistics.org/docs/#mean
+ */
+declare function meanSimple(
+  x: number[]
+):number
+
+export default meanSimple;

--- a/src/mean_simple.js
+++ b/src/mean_simple.js
@@ -1,0 +1,26 @@
+import sumSimple from "./sum_simple";
+
+/**
+ * The mean, _also known as average_,
+ * is the sum of all values over the number of values.
+ * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
+ * a method of finding a typical or central value of a set of numbers.
+ *
+ * This runs on `O(n)`, linear time in respect to the array
+ *
+ * @param {Array<number>} x sample of one or more data points
+ * @throws {Error} if the the length of x is less than one
+ * @returns {number} mean
+ * @example
+ * mean([0, 10]); // => 5
+ */
+function meanSimple(x) {
+    // The mean of no numbers is null
+    if (x.length === 0) {
+        throw new Error("mean requires at least one data point");
+    }
+
+    return sumSimple(x) / x.length;
+}
+
+export default meanSimple;

--- a/src/mean_simple.js
+++ b/src/mean_simple.js
@@ -6,7 +6,13 @@ import sumSimple from "./sum_simple";
  * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
  * a method of finding a typical or central value of a set of numbers.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * The simple mean uses the successive addition method internally
+ * to calculate it's result. Errors in floating-point addition are
+ * not accounted for, so if precision is required, the standard {@link mean}
+ * method should be used instead.
+ *
+ * This runs on `O(n)`, linear time in respect to the array.
+ *
  *
  * @param {Array<number>} x sample of one or more data points
  * @throws {Error} if the the length of x is less than one
@@ -17,7 +23,7 @@ import sumSimple from "./sum_simple";
 function meanSimple(x) {
     // The mean of no numbers is null
     if (x.length === 0) {
-        throw new Error("mean requires at least one data point");
+        throw new Error("meanSimple requires at least one data point");
     }
 
     return sumSimple(x) / x.length;

--- a/test/mean_simple.test.js
+++ b/test/mean_simple.test.js
@@ -1,0 +1,22 @@
+/* eslint no-shadow: 0 */
+
+const test = require("tap").test;
+const ss = require("../");
+
+test("meanSimple", function (t) {
+    t.test("can get the mean of two numbers", function (t) {
+        t.equal(ss.meanSimple([1, 2]), 1.5);
+        t.end();
+    });
+    t.test("can get the mean of one number", function (t) {
+        t.equal(ss.meanSimple([1]), 1);
+        t.end();
+    });
+    t.test("an empty list has no average", function (t) {
+        t.throws(function () {
+            ss.meanSimple([]);
+        });
+        t.end();
+    });
+    t.end();
+});


### PR DESCRIPTION
Internally, the standard `mean` function is using a `sum` function which goes beyond successive addition to correct for floating-point errors. The benchmarked `mean` function in the jStat library does not provide this, so the benchmark is not testing against which code is more performant, but instead testing two different algorithms.

Since the `sumSimple` function is already provided, it follows on that `meanSimple` can be used to provide an end user with an option for a more performant mean, at the cost of precision. This also allows the benchmark against jStat to be far closer, and in my tests actually outperforming.