### PR TITLE
test: Update Coveralls coverage reporting

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,3 +23,4 @@ jobs:
         yarn test
       env:
         CI: true
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A JavaScript implementation of descriptive, regression, and inference statistics.
 
-[![codecov.io](https://codecov.io/github/simple-statistics/simple-statistics/coverage.svg?branch=master)](https://codecov.io/github/simple-statistics/simple-statistics?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/simple-statistics/simple-statistics/badge.svg)](https://coveralls.io/github/simple-statistics/simple-statistics)
 [![npm version](https://badge.fury.io/js/simple-statistics.svg)](http://badge.fury.io/js/simple-statistics)
 
 Implemented in literate JavaScript with no dependencies, designed to work


### PR DESCRIPTION
We lost coverage reporting a while back - I'm not sure when, maybe I just forgot to port it in the switch to GitHub Actions. This tries to put it back.