### PR TITLE
feat: Add randomSource argument to permutationTest

### DIFF
--- a/src/permutation_test.d.ts
+++ b/src/permutation_test.d.ts
@@ -2,10 +2,11 @@
  * https://simplestatistics.org/docs/#permutationstest
  */
 declare function permutationTest(
-    sampleX: number[],
-    sampleY: number[],
-    string?: string,
-    k?: number
-): number
+  sampleX: number[],
+  sampleY: number[],
+  string?: string,
+  k?: number,
+  randomSource?: () => number
+): number;
 
 export default permutationTest;

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -15,6 +15,7 @@ import shuffleInPlace from "./shuffle_in_place";
  * @param {Array<number>} sampleY second dataset (e.g. control data)
  * @param {string} alternative alternative hypothesis, either 'two_sided' (default), 'greater', or 'less'
  * @param {number} k number of values in permutation distribution.
+ * @param {Function} [randomSource=Math.random] an optional entropy source
  * @returns {number} p-value The probability of observing the difference between groups (as or more extreme than what we did), assuming the null hypothesis.
  *
  * @example
@@ -22,7 +23,7 @@ import shuffleInPlace from "./shuffle_in_place";
  * var treatment = [20, 5, 13, 12, 7, 2, 2];
  * permutationTest(control, treatment); // ~0.1324
  */
-function permutationTest(sampleX, sampleY, alternative, k) {
+function permutationTest(sampleX, sampleY, alternative, k, randomSource) {
     // Set default arguments
     if (k === undefined) {
         k = 10000;
@@ -57,7 +58,7 @@ function permutationTest(sampleX, sampleY, alternative, k) {
 
     for (let i = 0; i < k; i++) {
         // 1. shuffle data assignments
-        shuffleInPlace(allData);
+        shuffleInPlace(allData, randomSource);
         const permLeft = allData.slice(0, midIndex);
         const permRight = allData.slice(midIndex, allData.length);
 

--- a/test/permutation_test.test.js
+++ b/test/permutation_test.test.js
@@ -1,13 +1,24 @@
 /* eslint no-shadow: 0 */
 
 const test = require("tap").test;
+const Random = require("random-js");
+const random = new Random.Random(Random.MersenneTwister19937.seed(0));
 const ss = require("../");
+
+function rng() {
+    return random.real(0, 1);
+}
 
 test("permutation test", function (t) {
     t.test(
         "P-value of identical distributions being different should be 1",
         function (t) {
-            t.equal(ss.permutationTest([2, 2, 2, 2, 2], [2, 2, 2, 2, 2]), 1);
+            t.equal(
+                ss.permutationTest([2, 2, 2, 2, 2], [2, 2, 2, 2, 2]),
+                1,
+                undefined,
+                rng
+            );
             t.end();
         }
     );
@@ -15,7 +26,13 @@ test("permutation test", function (t) {
         t
     ) {
         t.equal(
-            ss.permutationTest([2, 2, 2, 2, 2], [2, 2, 2, 2, 2], "greater"),
+            ss.permutationTest(
+                [2, 2, 2, 2, 2],
+                [2, 2, 2, 2, 2],
+                "greater",
+                undefined,
+                rng
+            ),
             1
         );
         t.end();
@@ -38,7 +55,9 @@ test("permutation test", function (t) {
                         99999,
                         99999
                     ],
-                    "less"
+                    "less",
+                    undefined,
+                    rng
                 ) < ss.epsilon
             );
             t.end();


### PR DESCRIPTION
Our tests were nondeterministic: testing permutationTest used Math.random indirectly, via shuffleInPlace. This adds a randomSource argument to permutationTest so it can be tested consistently.