### PR TITLE
Avoid unnecessary copy in shuffle

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -19,7 +19,7 @@ function shuffle(x, randomSource) {
     const sample = x.slice();
 
     // and then shuffle that shallow-copied array, in place
-    return shuffleInPlace(sample.slice(), randomSource);
+    return shuffleInPlace(sample, randomSource);
 }
 
 export default shuffle;


### PR DESCRIPTION
The previous implementation of shuffle created two shallow copies, one of which was unnecessary.