### PR TITLE
Link directly to Wikipedia instead of redirect

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -2,7 +2,8 @@ import modeSorted from "./mode_sorted";
 import numericSort from "./numeric_sort";
 
 /**
- * The [mode](http://bit.ly/W5K4Yt) is the number that appears in a list the highest number of times.
+ * The [mode](https://en.wikipedia.org/wiki/Mode_%28statistics%29) is the number
+ * that appears in a list the highest number of times.
  * There can be multiple modes in a list: in the event of a tie, this
  * algorithm will return the most recently seen mode.
  *

--- a/src/mode_fast.js
+++ b/src/mode_fast.js
@@ -1,7 +1,8 @@
 /* globals Map: false */
 
 /**
- * The [mode](http://bit.ly/W5K4Yt) is the number that appears in a list the highest number of times.
+ * The [mode](https://en.wikipedia.org/wiki/Mode_%28statistics%29) is the number
+ * that appears in a list the highest number of times.
  * There can be multiple modes in a list: in the event of a tie, this
  * algorithm will return the most recently seen mode.
  *

--- a/src/mode_sorted.js
+++ b/src/mode_sorted.js
@@ -1,5 +1,6 @@
 /**
- * The [mode](http://bit.ly/W5K4Yt) is the number that appears in a list the highest number of times.
+ * The [mode](https://en.wikipedia.org/wiki/Mode_%28statistics%29) is the number
+ * that appears in a list the highest number of times.
  * There can be multiple modes in a list: in the event of a tie, this
  * algorithm will return the most recently seen mode.
  *


### PR DESCRIPTION
From what I can tell, the redirect was used because the URL contains parentheses, which break markdown. This patch changes the third-party redirect to a direct URL with percent-encoded parentheses in accordance with the markdown and URI rules.

By the way, thanks for this project @tmcw!