### PR TITLE
Improve use of Big-O notation in src/docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Example:
  * this is the reciprocal of the arithmetic mean of the reciprocals
  * of the input numbers
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  */
 ```
 

--- a/src/extent.js
+++ b/src/extent.js
@@ -1,7 +1,7 @@
 /**
  * This computes the minimum & maximum number in an array.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @returns {Array<number>} minimum & maximum value

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -12,7 +12,7 @@
  * mean will correctly estimate a growth rate that, over those years,
  * will yield the same end value.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @returns {number} geometric mean

--- a/src/harmonic_mean.js
+++ b/src/harmonic_mean.js
@@ -7,7 +7,7 @@
  * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
  * a method of finding a typical or central value of a set of numbers.
  *
- * This runs on `O(n)`, linear time in respect to the array.
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @returns {number} harmonic mean

--- a/src/max.js
+++ b/src/max.js
@@ -1,7 +1,7 @@
 /**
  * This computes the maximum number in an array.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @returns {number} maximum value

--- a/src/mean.js
+++ b/src/mean.js
@@ -6,7 +6,7 @@ import sum from "./sum";
  * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
  * a method of finding a typical or central value of a set of numbers.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @throws {Error} if the the length of x is less than one

--- a/src/mean_simple.js
+++ b/src/mean_simple.js
@@ -11,7 +11,7 @@ import sumSimple from "./sum_simple";
  * not accounted for, so if precision is required, the standard {@link mean}
  * method should be used instead.
  *
- * This runs on `O(n)`, linear time in respect to the array.
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  *
  * @param {Array<number>} x sample of one or more data points

--- a/src/min.js
+++ b/src/min.js
@@ -1,5 +1,6 @@
 /**
- * The min is the lowest number in the array. This runs on `O(n)`, linear time in respect to the array
+ * The min is the lowest number in the array.
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x sample of one or more data points
  * @throws {Error} if the the length of x is less than one

--- a/src/mode.js
+++ b/src/mode.js
@@ -9,7 +9,7 @@ import numericSort from "./numeric_sort";
  * This is a [measure of central tendency](https://en.wikipedia.org/wiki/Central_tendency):
  * a method of finding a typical or central value of a set of numbers.
  *
- * This runs on `O(nlog(n))` because it needs to sort the array internally
+ * This runs in `O(n log(n))` because it needs to sort the array internally
  * before running an `O(n)` search to find the mode.
  *
  * @param {Array<number>} x input

--- a/src/product.js
+++ b/src/product.js
@@ -2,7 +2,7 @@
  * The [product](https://en.wikipedia.org/wiki/Product_(mathematics)) of an array
  * is the result of multiplying all numbers together, starting using one as the multiplicative identity.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x input
  * @return {number} product of all input numbers

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -4,7 +4,7 @@
  * of numbers, regardless of their sign.
  * This is the square root of the mean of the squares of the
  * input numbers.
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x a sample of one or more data points
  * @returns {number} root mean square

--- a/src/sum.js
+++ b/src/sum.js
@@ -9,7 +9,7 @@
  * algorithm is more accurate than the simple way of calculating sums by simple
  * addition.
  *
- * This runs on `O(n)`, linear time in respect to the array.
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x input
  * @return {number} sum of all input numbers

--- a/src/sum_simple.js
+++ b/src/sum_simple.js
@@ -2,7 +2,7 @@
  * The simple [sum](https://en.wikipedia.org/wiki/Summation) of an array
  * is the result of adding all numbers together, starting from zero.
  *
- * This runs on `O(n)`, linear time in respect to the array
+ * This runs in `O(n)`, linear time, with respect to the length of the array.
  *
  * @param {Array<number>} x input
  * @return {number} sum of all input numbers


### PR DESCRIPTION
I believe that this is more readable and closer to being grammatically correct.