### PR TITLE
fix: increase `ckmeans` performance

### DIFF
--- a/src/ckmeans.js
+++ b/src/ckmeans.js
@@ -70,7 +70,7 @@ function fillMatrixColumn(
     jlow = Math.max(jlow, backtrackMatrix[cluster - 1][i] || 0);
 
     let jhigh = i - 1; // the upper end for j
-    if (iMax < matrix.length - 1) {
+    if (iMax < matrix[0].length - 1) {
         jhigh = Math.min(jhigh, backtrackMatrix[cluster][iMax + 1] || 0);
     }
 


### PR DESCRIPTION
Fixes #520.

I don't know what I'm doing, but this way around it's closer to what the [reference implementation does](https://github.com/rocketrip/ckmeans/blob/49eb1bb9ca5467fdc153fe5d20f027ab7375c078/Ckmeans.1d.dp/src/Ckmeans.1d.dp.cpp#L102), and the tests still pass 🙃 

And it's way faster: Results using @breck7's test code from https://github.com/simple-statistics/simple-statistics/issues/520#issuecomment-719809868:

Before (without this fix):
```
kSize,nSize,time
5,1000,22
5,2000,33
5,10000,180
5,20000,820
5,100000,37749
5,200000,201173
```

After (with this fix):
```
kSize,nSize,time
5,1000,15
5,2000,29
5,10000,32
5,20000,52
5,100000,125
5,200000,324
```

cc @schnerd for review if you find the time, and this may be something you want to fix in your own ckmeans packages, too.