### PR TITLE
Add TypeScript bindings for silhouette.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,7 @@ export { default as bisect } from './src/bisect';
 
 // Clustering methods
 export { default as kMeansCluster } from './src/k_means_cluster';
+export { default as silhouette } from './src/silhouette';
 
 // Utils
 export { default as quickselect } from './src/quickselect';

--- a/src/silhouette.d.ts
+++ b/src/silhouette.d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simplestatistics.org/docs/#silhouette
+ */
+declare function silhouette(points: number[][], labels: number[]): number[];
+
+export default silhouette;


### PR DESCRIPTION
I found that the `silhouette` function was missing TypeScript bindings and could not be imported without them.  The goal of this PR is to add the necessary bindings for this function.