### PR TITLE
feat: Add rank correlation

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ export { default as equalIntervalBreaks } from "./src/equal_interval_breaks";
 // sample statistics
 export { default as sampleCovariance } from "./src/sample_covariance";
 export { default as sampleCorrelation } from "./src/sample_correlation";
+export { default as sampleRankCorrelation } from "./src/sample_rank_correlation";
 export { default as sampleVariance } from "./src/sample_variance";
 export { default as sampleStandardDeviation } from "./src/sample_standard_deviation";
 export { default as sampleSkewness } from "./src/sample_skewness";

--- a/src/sample_rank_correlation.d.ts
+++ b/src/sample_rank_correlation.d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simplestatistics.org/docs/#samplerankcorrelation
+ */
+declare function sampleRankCorrelation(x: number[], y: number[]): number;
+
+export default sampleRankCorrelation;

--- a/src/sample_rank_correlation.js
+++ b/src/sample_rank_correlation.js
@@ -1,0 +1,20 @@
+import sampleCorrelation from "./sample_correlation";
+
+/**
+ * The [rank correlation](https://en.wikipedia.org/wiki/Rank_correlation) is
+ * a measure of the strength of monotonic relationship between two arrays
+ *
+ * @param {Array<number>} x first input
+ * @param {Array<number>} y second input
+ * @returns {number} sample rank correlation
+ */
+function sampleRankCorrelation(x, y) {
+    const sortedX = x.slice().sort((a, b) => a - b);
+    const sortedY = y.slice().sort((a, b) => a - b);
+    const xRanks = x.map((a) => sortedX.indexOf(a));
+    const yRanks = y.map((a) => sortedY.indexOf(a));
+
+    return sampleCorrelation(xRanks, yRanks);
+}
+
+export default sampleRankCorrelation;

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -46,5 +46,37 @@ test("sample rank correlation", function (t) {
             t.end();
         }
     );
+
+    t.test("rank correlation agrees with R calculation", function (t) {
+        const x = [
+            -0.008718749,
+            -0.06111878,
+            0.067698537,
+            -1.075537181,
+            0.041328545,
+            0.56687373,
+            0.193619496,
+            -2.057133298,
+            -1.058808987,
+            -0.173177955
+        ];
+        const y = [
+            -3.02455481,
+            -1.30596109,
+            0.03873244,
+            -1.27909938,
+            -0.24630809,
+            -0.18103793,
+            -0.48281339,
+            -2.78997293,
+            -1.30551335,
+            -1.63361636
+        ];
+        const rankCorr = 0.6484848; // calculated using cor(x, y, method = "spearman") in R
+        if (Math.abs(ss.sampleRankCorrelation(x, y) - rankCorr) > ss.epsilon) {
+            t.fail("rank correlation is incorrect for sample data");
+        }
+        t.end();
+    });
     t.end();
 });

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -47,7 +47,7 @@ test("sample rank correlation", function (t) {
         }
     );
 
-    t.test("rank correlation agrees with R calculation", function (t) {
+    t.test("rank correlation agrees with R calculation for random data", function (t) {
         const x = [
             -0.008718749,
             -0.06111878,

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -30,3 +30,21 @@ test("sample correlation", function (t) {
 
     t.end();
 });
+
+test("sample rank correlation", function (t) {
+    t.test(
+        "absolute rank correlation for monotonic function equals one",
+        function (t) {
+            const x = [1, 2, 3, 4, 5, 6];
+            let y;
+            for (const sign of [-1, 1]) {
+                y = x.map((a) => sign * a * a);
+                if (rnd(ss.sampleRankCorrelation(x, y)) !== sign * 1) {
+                    t.fail("absolute rank correlation not equal to one");
+                }
+            }
+            t.end();
+        }
+    );
+    t.end();
+});

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -47,7 +47,7 @@ test("sample rank correlation", function (t) {
         }
     );
 
-    t.test("rank correlation agrees with R calculation for random data", function (t) {
+    t.test("rank correlation agrees with R calculation", function (t) {
         const x = [
             -0.008718749,
             -0.06111878,


### PR DESCRIPTION
This adds a calculation for [Spearman's rank correlation](https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient) which only requires us to extract the ranks of the two arrays before calling `sampleCorrelation`. Only caveat is this will use the minimum rank in the case of ties (e.g., `[1, 5, 5, 2, 4, 8]` will become `[0, 3, 3, 1, 2, 5]`).