### PR TITLE
Bump prettier and fix lint errors

### DIFF
--- a/test/binomial_distribution.test.js
+++ b/test/binomial_distribution.test.js
@@ -53,30 +53,31 @@ test("binomialDistribution", function (t) {
         }
     );
 
-    t.test("can return null when p or n are not valid parameters", function (
-        t
-    ) {
-        t.equal(
-            ss.binomialDistribution(0, 0.5),
-            undefined,
-            "n should be strictly positive"
-        );
-        t.equal(
-            ss.binomialDistribution(1.5, 0.5),
-            undefined,
-            "n should be an integer"
-        );
-        t.equal(
-            ss.binomialDistribution(2, -0.01),
-            undefined,
-            "p should be greater than 0.0"
-        );
-        t.equal(
-            ss.binomialDistribution(2, 1.5),
-            undefined,
-            "p should be less than 1.0"
-        );
-        t.end();
-    });
+    t.test(
+        "can return null when p or n are not valid parameters",
+        function (t) {
+            t.equal(
+                ss.binomialDistribution(0, 0.5),
+                undefined,
+                "n should be strictly positive"
+            );
+            t.equal(
+                ss.binomialDistribution(1.5, 0.5),
+                undefined,
+                "n should be an integer"
+            );
+            t.equal(
+                ss.binomialDistribution(2, -0.01),
+                undefined,
+                "p should be greater than 0.0"
+            );
+            t.equal(
+                ss.binomialDistribution(2, 1.5),
+                undefined,
+                "p should be less than 1.0"
+            );
+            t.end();
+        }
+    );
     t.end();
 });

--- a/test/coefficient_of_variation.test.js
+++ b/test/coefficient_of_variation.test.js
@@ -8,12 +8,13 @@ function rnd(x) {
 }
 
 test("coefficient_of_variation", function (t) {
-    t.test("can get the coefficientOfVariation of a six-sided die", function (
-        t
-    ) {
-        t.equal(rnd(ss.coefficientOfVariation([1, 2, 3, 4])), 0.516);
-        t.end();
-    });
+    t.test(
+        "can get the coefficientOfVariation of a six-sided die",
+        function (t) {
+            t.equal(rnd(ss.coefficientOfVariation([1, 2, 3, 4])), 0.516);
+            t.end();
+        }
+    );
 
     t.end();
 });

--- a/test/combinations.test.js
+++ b/test/combinations.test.js
@@ -8,15 +8,16 @@ test("combinations", function (t) {
         t.deepEqual(ss.combinations([1], 1), [[1]]);
         t.end();
     });
-    t.test("generates combinations of 1,2,3 choosing two at a time", function (
-        t
-    ) {
-        t.deepEqual(ss.combinations([1, 2, 3], 2), [
-            [1, 2],
-            [1, 3],
-            [2, 3]
-        ]);
-        t.end();
-    });
+    t.test(
+        "generates combinations of 1,2,3 choosing two at a time",
+        function (t) {
+            t.deepEqual(ss.combinations([1, 2, 3], 2), [
+                [1, 2],
+                [1, 3],
+                [2, 3]
+            ]);
+            t.end();
+        }
+    );
     t.end();
 });

--- a/test/k_means_cluster.test.js
+++ b/test/k_means_cluster.test.js
@@ -11,15 +11,16 @@ function nonRNG() {
 }
 
 test("k-means clustering test", function (t) {
-    t.test("Single cluster of one point contains only that point", function (
-        t
-    ) {
-        const points = [[0.5]];
-        const { labels, centroids } = ss.kMeansCluster(points, 1, nonRNG);
-        t.deepEqual(labels, [0]);
-        t.deepEqual(centroids, [[0.5]]);
-        t.end();
-    });
+    t.test(
+        "Single cluster of one point contains only that point",
+        function (t) {
+            const points = [[0.5]];
+            const { labels, centroids } = ss.kMeansCluster(points, 1, nonRNG);
+            t.deepEqual(labels, [0]);
+            t.deepEqual(centroids, [[0.5]]);
+            t.end();
+        }
+    );
 
     t.test("Single cluster of two points contains both points", function (t) {
         const points = [[0.0], [1.0]];

--- a/test/linear_regression.test.js
+++ b/test/linear_regression.test.js
@@ -5,35 +5,37 @@ const linearRegression = require("../").linearRegression;
 const linearRegressionLine = require("../").linearRegressionLine;
 
 test("linear regression", function (t) {
-    t.test("correctly generates a line for a 0, 0 to 1, 1 dataset", function (
-        t
-    ) {
-        const l = linearRegressionLine(
-            linearRegression([
-                [0, 0],
-                [1, 1]
-            ])
-        );
-        t.equal(l(0), 0);
-        t.equal(l(0.5), 0.5);
-        t.equal(l(1), 1);
-        t.end();
-    });
+    t.test(
+        "correctly generates a line for a 0, 0 to 1, 1 dataset",
+        function (t) {
+            const l = linearRegressionLine(
+                linearRegression([
+                    [0, 0],
+                    [1, 1]
+                ])
+            );
+            t.equal(l(0), 0);
+            t.equal(l(0.5), 0.5);
+            t.equal(l(1), 1);
+            t.end();
+        }
+    );
 
-    t.test("correctly generates a line for a 0, 0 to 1, 0 dataset", function (
-        t
-    ) {
-        const l = linearRegressionLine(
-            linearRegression([
-                [0, 0],
-                [1, 0]
-            ])
-        );
-        t.equal(l(0), 0);
-        t.equal(l(0.5), 0);
-        t.equal(l(1), 0);
-        t.end();
-    });
+    t.test(
+        "correctly generates a line for a 0, 0 to 1, 0 dataset",
+        function (t) {
+            const l = linearRegressionLine(
+                linearRegression([
+                    [0, 0],
+                    [1, 0]
+                ])
+            );
+            t.equal(l(0), 0);
+            t.equal(l(0.5), 0);
+            t.equal(l(1), 0);
+            t.end();
+        }
+    );
 
     t.test("handles a single-point sample", function (t) {
         const l = linearRegressionLine(linearRegression([[0, 0]]));

--- a/test/mad.test.js
+++ b/test/mad.test.js
@@ -4,12 +4,13 @@ const test = require("tap").test;
 const ss = require("../");
 
 test("median absolute deviation (mad)", function (t) {
-    t.test("median absolute deviation of an example on wikipedia", function (
-        t
-    ) {
-        t.equal(ss.mad([1, 1, 2, 2, 4, 6, 9]), 1);
-        t.end();
-    });
+    t.test(
+        "median absolute deviation of an example on wikipedia",
+        function (t) {
+            t.equal(ss.mad([1, 1, 2, 2, 4, 6, 9]), 1);
+            t.end();
+        }
+    );
 
     // wolfram alpha: median absolute deviation {0,1,2,3,4,5,6,7,8,9,10}
     t.test("median absolute deviation of 0-10", function (t) {

--- a/test/permutation_test.test.js
+++ b/test/permutation_test.test.js
@@ -22,21 +22,22 @@ test("permutation test", function (t) {
             t.end();
         }
     );
-    t.test("P-value of distribution less than itself should be 1", function (
-        t
-    ) {
-        t.equal(
-            ss.permutationTest(
-                [2, 2, 2, 2, 2],
-                [2, 2, 2, 2, 2],
-                "greater",
-                undefined,
-                rng
-            ),
-            1
-        );
-        t.end();
-    });
+    t.test(
+        "P-value of distribution less than itself should be 1",
+        function (t) {
+            t.equal(
+                ss.permutationTest(
+                    [2, 2, 2, 2, 2],
+                    [2, 2, 2, 2, 2],
+                    "greater",
+                    undefined,
+                    rng
+                ),
+                1
+            );
+            t.end();
+        }
+    );
     t.test(
         "P-value of small sample greater than large sample should be 0",
         function (t) {

--- a/test/r_squared.test.js
+++ b/test/r_squared.test.js
@@ -4,17 +4,18 @@ const test = require("tap").test;
 const ss = require("../");
 
 test("r-squared", function (t) {
-    t.test("says that the r squared of a two-point line is perfect", function (
-        t
-    ) {
-        const d = [
-            [0, 0],
-            [1, 1]
-        ];
-        const l = ss.linearRegressionLine(ss.linearRegression(d));
-        t.equal(ss.rSquared(d, l), 1);
-        t.end();
-    });
+    t.test(
+        "says that the r squared of a two-point line is perfect",
+        function (t) {
+            const d = [
+                [0, 0],
+                [1, 1]
+            ];
+            const l = ss.linearRegressionLine(ss.linearRegression(d));
+            t.equal(ss.rSquared(d, l), 1);
+            t.end();
+        }
+    );
 
     t.test(
         "says that the r squared of a three-point line is not perfect",

--- a/test/sample_covariance.test.js
+++ b/test/sample_covariance.test.js
@@ -21,14 +21,15 @@ test("sample covariance", function (t) {
         t.end();
     });
 
-    t.test("covariance is zero for something with no correlation", function (
-        t
-    ) {
-        const x = [1, 2, 3, 4, 5, 6];
-        const y = [1, 1, 2, 2, 1, 1];
-        t.equal(rnd(ss.sampleCovariance(x, y)), 0);
-        t.end();
-    });
+    t.test(
+        "covariance is zero for something with no correlation",
+        function (t) {
+            const x = [1, 2, 3, 4, 5, 6];
+            const y = [1, 1, 2, 2, 1, 1];
+            t.equal(rnd(ss.sampleCovariance(x, y)), 0);
+            t.end();
+        }
+    );
 
     t.test("zero-length corner case", function (t) {
         t.throws(function () {

--- a/test/sample_kurtosis.test.js
+++ b/test/sample_kurtosis.test.js
@@ -28,15 +28,16 @@ test("sample kurtosis", function (t) {
         t.end();
     });
 
-    t.test("the kurtosis of an sample with three numbers is null", function (
-        t
-    ) {
-        const data = [1, 2, 3];
-        t.throws(function () {
-            ss.sampleKurtosis(data);
-        });
-        t.end();
-    });
+    t.test(
+        "the kurtosis of an sample with three numbers is null",
+        function (t) {
+            const data = [1, 2, 3];
+            t.throws(function () {
+                ss.sampleKurtosis(data);
+            });
+            t.end();
+        }
+    );
 
     t.test("can calculate the kurtosis of SAS example 1", function (t) {
         // Data and answer taken from KURTOSIS function documentation at

--- a/yarn.lock
+++ b/yarn.lock
@@ -5330,9 +5330,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This bumps prettier in `yarn.lock` and fixes the resulting lint errors. (I noticed there was a PR from dependabot only bumping the version; not totally sure how dependabot works but I think this PR can supersede that one.)

With this change cloning locally and then simply doing
```
npm install
npm run test
```
should result in clean output.