### PR TITLE
Rank correlation

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ export { default as equalIntervalBreaks } from "./src/equal_interval_breaks";
 // sample statistics
 export { default as sampleCovariance } from "./src/sample_covariance";
 export { default as sampleCorrelation } from "./src/sample_correlation";
+export { default as sampleRankCorrelation } from "./src/sample_rank_correlation";
 export { default as sampleVariance } from "./src/sample_variance";
 export { default as sampleStandardDeviation } from "./src/sample_standard_deviation";
 export { default as sampleSkewness } from "./src/sample_skewness";

--- a/src/sample_rank_correlation.d.ts
+++ b/src/sample_rank_correlation.d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simplestatistics.org/docs/#samplerankcorrelation
+ */
+declare function sampleRankCorrelation(x: number[], y: number[]): number;
+
+export default sampleRankCorrelation;

--- a/src/sample_rank_correlation.js
+++ b/src/sample_rank_correlation.js
@@ -1,0 +1,20 @@
+import sampleCorrelation from "./sample_correlation";
+
+/**
+ * The [rank correlation](https://en.wikipedia.org/wiki/Rank_correlation) is
+ * a measure of the strength of monotonic relationship between two arrays
+ *
+ * @param {Array<number>} x first input
+ * @param {Array<number>} y second input
+ * @returns {number} sample rank correlation
+ */
+function sampleRankCorrelation(x, y) {
+    const sortedX = x.slice().sort((a, b) => a - b);
+    const sortedY = y.slice().sort((a, b) => a - b);
+    const xRanks = x.map((a) => sortedX.indexOf(a));
+    const yRanks = y.map((a) => sortedY.indexOf(a));
+
+    return sampleCorrelation(xRanks, yRanks);
+}
+
+export default sampleRankCorrelation;

--- a/src/sample_rank_correlation.js
+++ b/src/sample_rank_correlation.js
@@ -9,10 +9,24 @@ import sampleCorrelation from "./sample_correlation";
  * @returns {number} sample rank correlation
  */
 function sampleRankCorrelation(x, y) {
-    const sortedX = x.slice().sort((a, b) => a - b);
-    const sortedY = y.slice().sort((a, b) => a - b);
-    const xRanks = x.map((a) => sortedX.indexOf(a));
-    const yRanks = y.map((a) => sortedY.indexOf(a));
+    const xIndexes = x
+        .map((value, index) => [value, index])
+        .sort((a, b) => a[0] - b[0])
+        .map((pair) => pair[1]);
+    const yIndexes = y
+        .map((value, index) => [value, index])
+        .sort((a, b) => a[0] - b[0])
+        .map((pair) => pair[1]);
+
+    // At this step, we have an array of indexes
+    // that map from sorted numbers to their original indexes. We reverse
+    // that so that it is an array of the sorted destination index.
+    const xRanks = Array(xIndexes.length);
+    const yRanks = Array(xIndexes.length);
+    for (let i = 0; i < xIndexes.length; i++) {
+        xRanks[xIndexes[i]] = i;
+        yRanks[yIndexes[i]] = i;
+    }
 
     return sampleCorrelation(xRanks, yRanks);
 }

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -46,5 +46,37 @@ test("sample rank correlation", function (t) {
             t.end();
         }
     );
+
+    t.test("rank correlation agrees with R calculation", function (t) {
+        const x = [
+            -0.008718749,
+            -0.06111878,
+            0.067698537,
+            -1.075537181,
+            0.041328545,
+            0.56687373,
+            0.193619496,
+            -2.057133298,
+            -1.058808987,
+            -0.173177955
+        ];
+        const y = [
+            -3.02455481,
+            -1.30596109,
+            0.03873244,
+            -1.27909938,
+            -0.24630809,
+            -0.18103793,
+            -0.48281339,
+            -2.78997293,
+            -1.30551335,
+            -1.63361636
+        ];
+        const rankCorr = 0.6484848; // calculated using cor(x, y, method = "spearman") in R
+        if (Math.abs(ss.sampleRankCorrelation(x, y) - rankCorr) > ss.epsilon) {
+            t.fail("rank correlation is incorrect for sample data");
+        }
+        t.end();
+    });
     t.end();
 });

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -47,7 +47,7 @@ test("sample rank correlation", function (t) {
         }
     );
 
-    t.test("rank correlation agrees with R calculation", function (t) {
+    t.test("rank correlation agrees with R calculation for random data", function (t) {
         const x = [
             -0.008718749,
             -0.06111878,

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -30,3 +30,21 @@ test("sample correlation", function (t) {
 
     t.end();
 });
+
+test("sample rank correlation", function (t) {
+    t.test(
+        "absolute rank correlation for monotonic function equals one",
+        function (t) {
+            const x = [1, 2, 3, 4, 5, 6];
+            let y;
+            for (const sign of [-1, 1]) {
+                y = x.map((a) => sign * a * a);
+                if (rnd(ss.sampleRankCorrelation(x, y)) !== sign * 1) {
+                    t.fail("absolute rank correlation not equal to one");
+                }
+            }
+            t.end();
+        }
+    );
+    t.end();
+});

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -47,7 +47,7 @@ test("sample rank correlation", function (t) {
         }
     );
 
-    t.test("rank correlation agrees with R calculation for random data", function (t) {
+    t.test("rank correlation agrees with R calculation", function (t) {
         const x = [
             -0.008718749,
             -0.06111878,

--- a/test/sample_correlation.test.js
+++ b/test/sample_correlation.test.js
@@ -74,6 +74,7 @@ test("sample rank correlation", function (t) {
         ];
         const rankCorr = 0.6484848; // calculated using cor(x, y, method = "spearman") in R
         if (Math.abs(ss.sampleRankCorrelation(x, y) - rankCorr) > ss.epsilon) {
+            console.log(ss.sampleRankCorrelation(x, y));
             t.fail("rank correlation is incorrect for sample data");
         }
         t.end();


### PR DESCRIPTION
@dsaxton for your consideration, decided to take a shot at seeing whether we could support duplicate indexes in this algorithm. This does, by first recording the indexes before sorting.

The benefits are that this supports duplicate values and also improves performance (in big-o terms) because it removes the `indexOf`, which was in the worst case was n².

On the downside, it's a bit more code, and it will use a little more memory, in the form of temporary arrays.