### PR TITLE
Shuffle less during sample

### DIFF
--- a/src/sample.js
+++ b/src/sample.js
@@ -1,4 +1,4 @@
-import shuffle from "./shuffle";
+import shuffleSubsetInPlace from "./shuffle_subset_in_place";
 
 /**
  * Create a [simple random sample](http://en.wikipedia.org/wiki/Simple_random_sample)
@@ -18,11 +18,9 @@ import shuffle from "./shuffle";
  * sample(values, 3); // returns 3 random values, like [2, 5, 8];
  */
 function sample(x, n, randomSource) {
-    // shuffle the original array using a fisher-yates shuffle
-    const shuffled = shuffle(x, randomSource);
-
-    // and then return a subset of it - the first `n` elements.
-    return shuffled.slice(0, n);
+    const data = x.slice();
+    // shuffle the tail of the array using a fisher-yates shuffle
+    return shuffleSubsetInPlace(data, n, randomSource);
 }
 
 export default sample;

--- a/src/shuffle_in_place.js
+++ b/src/shuffle_in_place.js
@@ -1,3 +1,5 @@
+import shuffleSubsetInPlace from "./shuffle_subset_in_place";
+
 /**
  * A [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
  * in-place - which means that it **will change the order of the original
@@ -16,37 +18,7 @@
  * // x is shuffled to a value like [2, 1, 4, 3]
  */
 function shuffleInPlace(x, randomSource) {
-    // a custom random number source can be provided if you want to use
-    // a fixed seed or another random number generator, like
-    // [random-js](https://www.npmjs.org/package/random-js)
-    randomSource = randomSource || Math.random;
-
-    // store the current length of the x to determine
-    // when no elements remain to shuffle.
-    let length = x.length;
-
-    // temporary is used to hold an item when it is being
-    // swapped between indices.
-    let temporary;
-
-    // The index to swap at each stage.
-    let index;
-
-    // While there are still items to shuffle
-    while (length > 0) {
-        // choose a random index within the subset of the array
-        // that is not yet shuffled
-        index = Math.floor(randomSource() * length--);
-
-        // store the value that we'll move temporarily
-        temporary = x[length];
-
-        // swap the value at `x[length]` with `x[index]`
-        x[length] = x[index];
-        x[index] = temporary;
-    }
-
-    return x;
+    return shuffleSubsetInPlace(x, x.length, randomSource);
 }
 
 export default shuffleInPlace;

--- a/src/shuffle_subset_in_place.js
+++ b/src/shuffle_subset_in_place.js
@@ -1,0 +1,35 @@
+function shuffleSubsetInPlace(x, n, randomSource) {
+    // a custom random number source can be provided if you want to use
+    // a fixed seed or another random number generator, like
+    // [random-js](https://www.npmjs.org/package/random-js)
+    randomSource = randomSource || Math.random;
+
+    // store the current length of the x to determine
+    // when no elements remain to shuffle.
+    let length = x.length;
+
+    // temporary is used to hold an item when it is being
+    // swapped between indices.
+    let temporary;
+
+    // The index to swap at each stage.
+    let index;
+
+    // While there are still items to shuffle
+    while (length > Math.max(x.length - n, 0)) {
+        // choose a random index within the subset of the array
+        // that is not yet shuffled
+        index = Math.floor(randomSource() * length--);
+
+        // store the value that we'll move temporarily
+        temporary = x[length];
+
+        // swap the value at `x[length]` with `x[index]`
+        x[length] = x[index];
+        x[index] = temporary;
+    }
+
+    return x.slice(x.length - n);
+}
+
+export default shuffleSubsetInPlace;

--- a/test/k_means_cluster.test.js
+++ b/test/k_means_cluster.test.js
@@ -78,10 +78,10 @@ test("k-means clustering test", function (t) {
                 [0.1, 0.0]
             ];
             const { labels, centroids } = ss.kMeansCluster(points, 2, nonRNG);
-            t.deepEqual(labels, [0, 1, 0]);
+            t.deepEqual(labels, [1, 0, 1]);
             t.deepEqual(centroids, [
-                [0.05, 0.25],
-                [1.0, 0.5]
+                [1.0, 0.5],
+                [0.05, 0.25]
             ]);
             t.end();
         }

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -13,11 +13,11 @@ test("sample", function (t) {
     t.deepEqual(ss.sample([], 0, rng), [], "edge case - zero array");
     t.deepEqual(ss.sample([], 2, rng), [], "edge case - zero array");
     t.deepEqual(ss.sample([1, 2, 3], 0, rng, 0), [], "edge case - zero array");
-    t.deepEqual(ss.sample([1, 2, 3], 1, rng), [1], "edge case - sample of 1");
-    t.deepEqual(ss.sample([1, 2, 3], 1, rng), [2]);
-    t.deepEqual(ss.sample([1, 2, 3], 3, rng), [2, 3, 1]);
-    t.deepEqual(ss.sample([1, 2, 3, 4], 2, rng), [3, 1]);
-    t.deepEqual(ss.sample([1, 2, 3, 4, 6, 7, 8], 2, rng), [8, 7]);
+    t.deepEqual(ss.sample([1, 2, 3], 1, rng), [3], "edge case - sample of 1");
+    t.deepEqual(ss.sample([1, 2, 3], 1, rng), [3]);
+    t.deepEqual(ss.sample([1, 2, 3], 3, rng), [1, 3, 2]);
+    t.deepEqual(ss.sample([1, 2, 3, 4], 2, rng), [1, 4]);
+    t.deepEqual(ss.sample([1, 2, 3, 4, 6, 7, 8], 2, rng), [4, 3]);
     t.deepEqual(
         ss.sample(["foo", "bar"], 1, rng),
         ["foo"],


### PR DESCRIPTION
xref https://github.com/simple-statistics/simple-statistics/issues/250

Made an attempt at improving the efficiency of `sample` a little bit. To do that we're generalizing the `shuffleInPlace` function to `shuffleSubsetInPlace` (open to suggestions for other names; in any case this wouldn't be exposed through the public API) which accepts the number of iterations in the Fisher-Yates shuffle as an additional argument. We then only swap that number of elements and return the selected values from the tail of the array. We can also now treat `shuffleInPlace` as a special case where the number of iterations equals the sample size.

I'm not sure what's going on with the tests, but something with the random number generator seems to be causing output to change. What's being returned now still appears "correct" to me, so I think it should be okay to simply update these.