### PR TITLE
feat: Implement Wilcoxon rank sum statistic

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ export { default as variance } from "./src/variance";
 export { default as coefficientOfVariation } from "./src/coefficient_of_variation";
 export { default as tTest } from "./src/t_test";
 export { default as tTestTwoSample } from "./src/t_test_two_sample";
+export { default as wilcoxonRankSum } from "./src/wilcoxon_rank_sum";
 // ss.jenks = require('./src/jenks');
 
 // Classifiers

--- a/src/wilcoxon_rank_sum..d.ts
+++ b/src/wilcoxon_rank_sum..d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simplestatistics.org/docs/#wilcoxonranksum
+ */
+declare function wilcoxonRankSum(sampleX: number[], sampleY: number[]): number;
+
+export default wilcoxonRankSum;

--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -24,8 +24,11 @@ function wilcoxonRankSum(sampleX, sampleY) {
     const pooledSamples = sampleX
         .map((x) => ({ label: "x", value: x }))
         .concat(sampleY.map((y) => ({ label: "y", value: y })))
-        .sort((a, b) => a.value - b.value)
-        .map((s, idx) => ({ label: s.label, value: s.value, rank: idx }));
+        .sort((a, b) => a.value - b.value);
+
+    for (let rank = 0; rank < pooledSamples.length; rank++) {
+        pooledSamples[rank].rank = rank;
+    }
 
     let tiedRanks = [pooledSamples[0].rank];
     for (let i = 1; i < pooledSamples.length; i++) {

--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -1,0 +1,57 @@
+/**
+ * This function calculates the Wilcoxon rank sum statistic for the first sample
+ * with respect to the second. The Wilcoxon rank sum test is a non-parametric
+ * alternative to the t-test which is equivalent to the
+ * [Mann-Whitney U test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test).
+ * The statistic is calculated by pooling all the observations together, ranking them,
+ * and then summing the ranks associated with one of the samples. If this rank sum is
+ * sufficiently large or small we reject the hypothesis that the two samples come
+ * from the same distribution in favor of the alternative that one is shifted with
+ * respect to the other.
+ *
+ * @param {Array<number>} sampleX a sample as an array of numbers
+ * @param {Array<number>} sampleY a sample as an array of numbers
+ * @returns {number} rank sum for sampleX
+ *
+ * @example
+ * wilcoxonRankSum([1, 4, 8], [9, 12, 15]); // => 6
+ */
+function wilcoxonRankSum(sampleX, sampleY) {
+    if (!sampleX.length || !sampleY.length) {
+        throw new Error("Neither sample can be empty");
+    }
+
+    const pooledSamples = sampleX
+        .map((x) => ({ label: "x", value: x }))
+        .concat(sampleY.map((y) => ({ label: "y", value: y })))
+        .sort((a, b) => a.value - b.value)
+        .map((s, idx) => ({ label: s.label, value: s.value, rank: idx }));
+
+    let tiedRanks = [pooledSamples[0].rank];
+    for (let i = 1; i < pooledSamples.length; i++) {
+        if (pooledSamples[i].value === pooledSamples[i - 1].value) {
+            tiedRanks.push(pooledSamples[i].rank);
+            if (i === pooledSamples.length - 1) {
+                replaceRanksInPlace(pooledSamples, tiedRanks);
+            }
+        } else if (tiedRanks.length > 1) {
+            replaceRanksInPlace(pooledSamples, tiedRanks);
+        } else {
+            tiedRanks = [pooledSamples[i].rank];
+        }
+    }
+
+    function replaceRanksInPlace(pooledSamples, tiedRanks) {
+        const average = (tiedRanks[0] + tiedRanks[tiedRanks.length - 1]) / 2;
+        for (let i = 0; i < tiedRanks.length; i++) {
+            pooledSamples[tiedRanks[i]].rank = average;
+        }
+    }
+
+    return pooledSamples
+        .filter((s) => s.label === "x")
+        .map((s) => s.rank + 1)
+        .reduce((a, b) => a + b);
+}
+
+export default wilcoxonRankSum;

--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -51,10 +51,16 @@ function wilcoxonRankSum(sampleX, sampleY) {
         }
     }
 
-    return pooledSamples
-        .filter((s) => s.label === "x")
-        .map((s) => s.rank + 1)
-        .reduce((a, b) => a + b);
+    let rankSum = 0;
+
+    for (let i = 0; i < pooledSamples.length; i++) {
+        const sample = pooledSamples[i];
+        if (sample.label === "x") {
+            rankSum += sample.rank + 1;
+        }
+    }
+
+    return rankSum;
 }
 
 export default wilcoxonRankSum;

--- a/test/wilcoxon_rank_sum.test.js
+++ b/test/wilcoxon_rank_sum.test.js
@@ -1,0 +1,62 @@
+/* eslint no-shadow: 0 */
+
+const test = require("tap").test;
+const ss = require("../");
+
+test("wilcoxonRankSum", function (t) {
+    t.test("x is dominated by y", function (t) {
+        const x = [1, 2, 3];
+        const y = [4, 5, 6];
+        const res = ss.wilcoxonRankSum(x, y);
+        t.equal(res, 6);
+        t.end();
+    });
+
+    t.test("y is dominated by x", function (t) {
+        const x = [4, 5, 6];
+        const y = [1, 2, 3];
+        const res = ss.wilcoxonRankSum(x, y);
+        t.equal(res, 15);
+        t.end();
+    });
+
+    t.test("x and y are interleaved", function (t) {
+        const x = [1, 3, 5];
+        const y = [2, 4, 6];
+        const res = ss.wilcoxonRankSum(x, y);
+        t.equal(res, 9);
+        t.end();
+    });
+
+    t.test("x and y overlap at one value", function (t) {
+        const x = [1, 2, 3];
+        const y = [3, 4, 5];
+        const res = ss.wilcoxonRankSum(x, y);
+        t.equal(res, 6.5);
+        t.end();
+    });
+
+    t.test("trailing tied ranks are handled correctly", function (t) {
+        const x = [1, 2, 3];
+        const y = [3];
+        const res = ss.wilcoxonRankSum(x, y);
+        t.equal(res, 6.5);
+        t.end();
+    });
+
+    t.test("empty input throws", function (t) {
+        const message = "Neither sample can be empty";
+        t.throws(function () {
+            ss.wilcoxonRankSum([], []);
+        }, message);
+        t.throws(function () {
+            ss.wilcoxonRankSum([1, 2, 3], []);
+        }, message);
+        t.throws(function () {
+            ss.wilcoxonRankSum([], [1, 2, 3]);
+        }, message);
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
@tmcw I'm not sure if this is something you'd be interested in adding, but this PR implements a calculation of the Wilcoxon rank sum statistic, which is a popular non-parametric alternative to the two sample t-test. The code gets a tad messy, primarily because we need to make sure that ranks of tied values get replaced by the average rank within the group (else the statistic isn't well-defined). Please let me know if you think there's a more elegant way to do this.

Also worth pointing out that this _only_ calculates the value of the test statistic, and doesn't provide any utilities for performing inference on that value.