### PR TITLE
Add missing TypeScript typing for `silhouetteMetric`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,9 +92,10 @@ export { default as permutationTest } from "./src/permutation_test";
 // Root-finding methods
 export { default as bisect } from './src/bisect';
 
-// Clustering methods
+// Clustering methods and metrics
 export { default as kMeansCluster } from './src/k_means_cluster';
 export { default as silhouette } from './src/silhouette';
+export { default as silhouetteMetric } from './src/silhouette_metric';
 
 // Utils
 export { default as quickselect } from './src/quickselect';

--- a/src/silhouette_metric.d.ts
+++ b/src/silhouette_metric.d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simplestatistics.org/docs/#silhouettemetric
+ */
+declare function silhouetteMetric(points: number[][], labels: number[]): number;
+
+export default silhouetteMetric;


### PR DESCRIPTION
The typings were `silhouette` were also forgot in the original implementation (https://github.com/simple-statistics/simple-statistics/pull/485) but that was fixed here: https://github.com/simple-statistics/simple-statistics/pull/549