### PR TITLE
build: Include LICENSE file in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "src",
     "dist",
+    "LICENSE",
     "index.js",
     "index.d.ts"
   ],


### PR DESCRIPTION
Via [Socket](https://socket.dev/npm/package/simple-statistics), I've realized that the LICENSE file for this module isn't included in the npm module. This will include it.

No change to the licensing, just making sure that the file is included.