### PR TITLE
Support TypeScript nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/simple-statistics.mjs",
-      "require": "./dist/simple-statistics.js"
+      "require": "./dist/simple-statistics.js",
+      "types": "./index.d.ts"
     }
   },
   "engines": {


### PR DESCRIPTION
Quick fix, the export map needs a `types` field with nodenext resolution and doesn't use the root `types` field