### PR TITLE
build: Add browser to exports in package.json. Move TS to the top.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/simple-statistics.mjs",
-      "require": "./dist/simple-statistics.js",
-      "types": "./index.d.ts"
+      "browser": "dist/simple-statistics.min.js",
+      "require": "./dist/simple-statistics.js"
     }
   },
   "engines": {


### PR DESCRIPTION
- Fixes #527

Via publint's checking https://publint.dev/simple-statistics@7.8.1

Oddly typescript requires the `types` member to be first in the `exports` object. Odd!