### PR TITLE
bugfix: fix the export path of browser from dist/simple-statistics.mi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ".": {
       "types": "./index.d.ts",
       "import": "./dist/simple-statistics.mjs",
-      "browser": "dist/simple-statistics.min.js",
+      "browser": "./dist/simple-statistics.min.js",
       "require": "./dist/simple-statistics.js"
     }
   },


### PR DESCRIPTION
hi,
I fix the export path of browser from "dist/simple-statistics.min.js" to "./dist/simple-statistics.min.js".
I got a problem when I build my project which use simple-statistics， like :
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/7625172/217528180-984be129-e84b-4826-b22d-36cbb8769b58.png">
I think it the problem of export path of browser，please check the pull request

thank you 