### PR TITLE
build: Switch from volta to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"
+pnpm = "latest"

--- a/package.json
+++ b/package.json
@@ -7,13 +7,7 @@
         "type": "git",
         "url": "git://github.com/simple-statistics/simple-statistics.git"
     },
-    "files": [
-        "src",
-        "dist",
-        "LICENSE",
-        "index.js",
-        "index.d.ts"
-    ],
+    "files": ["src", "dist", "LICENSE", "index.js", "index.d.ts"],
     "devDependencies": {
         "@biomejs/biome": "^1.8.3",
         "@rollup/plugin-buble": "^1.0.3",
@@ -69,7 +63,7 @@
             "path": "./node_modules/cz-conventional-changelog"
         }
     },
-    "volta": {
-        "node": "20.16.0"
+    "pnpm": {
+        "onlyBuiltDependencies": ["@biomejs/biome"]
     }
 }


### PR DESCRIPTION
I've switched all my local-tools version management to `mise`, so switching this project as well. It's great.