### PR TITLE
Drop node 18 from test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
A new version of TAP brought in the latest version of uuid which uses the global `crypto` object that doesn't exist for Node 18. Dropping Node 18 which has been EOL for years from the test matrix.