### PR TITLE
fix: permutationTest uses original sample sizes for unequal-length samples

### DIFF
--- a/.changeset/permutation-test-unequal-sizes.md
+++ b/.changeset/permutation-test-unequal-sizes.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+fix: permutationTest now keeps the original sample sizes when permuting unequal-length samples

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -54,13 +54,17 @@ function permutationTest(sampleX, sampleY, alternative, k, randomSource) {
 
     // combine datsets so we can easily shuffle later
     const allData = sampleX.concat(sampleY);
-    const midIndex = Math.floor(allData.length / 2);
+    // Each permutation reassigns the pooled values into two groups that keep
+    // the original sample sizes. Splitting at the midpoint only matches when
+    // both samples are the same length; for unequal samples it built the
+    // permutation distribution from the wrong group sizes.
+    const splitIndex = sampleX.length;
 
     for (let i = 0; i < k; i++) {
         // 1. shuffle data assignments
         shuffleInPlace(allData, randomSource);
-        const permLeft = allData.slice(0, midIndex);
-        const permRight = allData.slice(midIndex, allData.length);
+        const permLeft = allData.slice(0, splitIndex);
+        const permRight = allData.slice(splitIndex, allData.length);
 
         // 2.re-calculate test statistic
         const permTestStatistic = mean(permLeft) - mean(permRight);

--- a/test/permutation_test.test.js
+++ b/test/permutation_test.test.js
@@ -67,5 +67,20 @@ test("permutation test", function (t) {
         }
     );
 
+    t.test("handles samples of unequal length", function (t) {
+        // Each permutation keeps the original group sizes (3 and 1). The
+        // observed difference is mean([10, 10, 10]) - mean([0]) = 10, which a
+        // permutation can match only when the single 0 lands in the second
+        // group, one quarter of the time. Splitting the pool in half instead
+        // compared this against 2-vs-2 permutations, whose mean difference can
+        // never reach 10, so the p-value collapsed to 0.
+        const seeded = new Random.Random(Random.MersenneTwister19937.seed(42));
+        const p = ss.permutationTest([10, 10, 10], [0], "two_side", 10000, () =>
+            seeded.real(0, 1)
+        );
+        t.ok(Math.abs(p - 0.25) < 0.05);
+        t.end();
+    });
+
     t.end();
 });

--- a/test/permutation_test.test.js
+++ b/test/permutation_test.test.js
@@ -51,4 +51,18 @@ describe("permutation test", function () {
             ss.permutationTest([1, 69, 420], [42, 42, 42], "one-tailed");
         });
     });
+
+    it("handles samples of unequal length", function () {
+        // Each permutation keeps the original group sizes (3 and 1). The
+        // observed difference is mean([10, 10, 10]) - mean([0]) = 10, which a
+        // permutation can match only when the single 0 lands in the second
+        // group, one quarter of the time. Splitting the pool in half instead
+        // compared this against 2-vs-2 permutations, whose mean difference can
+        // never reach 10, so the p-value collapsed to 0.
+        const seeded = new Random.Random(Random.MersenneTwister19937.seed(42));
+        const p = ss.permutationTest([10, 10, 10], [0], "two_side", 10000, () =>
+            seeded.real(0, 1)
+        );
+        assert.ok(Math.abs(p - 0.25) < 0.05);
+    });
 });


### PR DESCRIPTION
`permutationTest` builds its null distribution by shuffling the pooled data and re-splitting it, but it splits at the midpoint of the combined array:

```js
const allData = sampleX.concat(sampleY);
const midIndex = Math.floor(allData.length / 2);
```

The observed statistic is `mean(sampleX) - mean(sampleY)`, computed on the real group sizes, while every permutation statistic is `mean(left) - mean(right)` on two equal halves. Those line up only when `sampleX` and `sampleY` have the same length. For unequal samples the permutation distribution is built from the wrong group sizes, so the resulting p-value is not meaningful.

Concrete case: `permutationTest([10, 10, 10], [0], "two_side")`. The observed difference is `10`. The pool `[10, 10, 10, 0]` gets split 2-vs-2, whose mean difference is at most `5`, so no permutation reaches `10` and the p-value collapses to `0`. The correct value is `0.25`, since only the arrangement that isolates the `0` is as extreme as the observed difference.

The fix splits each shuffled pool at `sampleX.length`, so the two groups keep their original sizes. When the samples are already equal length this is the same as the old midpoint (`floor(2n / 2) === n`), so existing results do not change. I added a regression test for the unequal-length case.

`tap test/*.test.js` passes (782 assertions) and `biome check` is clean. The midpoint split has been there since the function was added in #288.
