### PR TITLE
Fix quantile() returning wrong values for some requested quantile sets

### DIFF
--- a/.changeset/pretty-rooms-open.md
+++ b/.changeset/pretty-rooms-open.md
@@ -1,0 +1,8 @@
+---
+"simple-statistics": patch
+---
+
+Fix quantile() bug when an array was provided as the second argument
+
+Thanks [Alexander Kireyev](https://github.com/chatman-media) for the identification
+and fix.

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -53,29 +53,34 @@ function quantileSelect(arr, k, left, right) {
 }
 
 function multiQuantileSelect(arr, p) {
-    const indices = [0];
+    // Collect every integer order statistic that the requested quantiles need.
+    // Linear interpolation (type=7) reads x[floor(idx)] and x[ceil(idx)], so both
+    // surrounding positions must be placed. Deduplicate to integer positions
+    // (including the endpoints) so each is selected with an unambiguous index.
+    const positions = new Set([0, arr.length - 1]);
     for (let i = 0; i < p.length; i++) {
-        indices.push(quantileIndex(arr.length, p[i]));
+        const idx = quantileIndex(arr.length, p[i]);
+        positions.add(Math.floor(idx));
+        positions.add(Math.ceil(idx));
     }
-    indices.push(arr.length - 1);
-    indices.sort(compare);
+    const indices = Array.from(positions).sort(compare);
 
-    const stack = [0, indices.length - 1];
-
+    // Recursively partition around the median requested position, then the two
+    // halves. The just-placed pivot is excluded from the child ranges so that a
+    // later, narrower quickselect cannot disturb an already-finalized position.
+    const stack = [0, indices.length - 1, 0, arr.length - 1];
     while (stack.length) {
-        const r = Math.ceil(stack.pop());
-        const l = Math.floor(stack.pop());
-        if (r - l <= 1) continue;
+        const right = stack.pop();
+        const left = stack.pop();
+        const r = stack.pop();
+        const l = stack.pop();
+        if (l > r) continue;
 
-        const m = Math.floor((l + r) / 2);
-        quantileSelect(
-            arr,
-            indices[m],
-            Math.floor(indices[l]),
-            Math.ceil(indices[r])
-        );
+        const m = (l + r) >> 1;
+        quickselect(arr, indices[m], left, right);
 
-        stack.push(l, m, m, r);
+        stack.push(l, m - 1, left, indices[m] - 1);
+        stack.push(m + 1, r, indices[m] + 1, right);
     }
 }
 

--- a/src/quantile.js
+++ b/src/quantile.js
@@ -56,8 +56,8 @@ function multiQuantileSelect(arr, p) {
     // Collect every integer order statistic that the requested quantiles need.
     // Linear interpolation (type=7) reads x[floor(idx)] and x[ceil(idx)], so both
     // surrounding positions must be placed. Deduplicate to integer positions
-    // (including the endpoints) so each is selected with an unambiguous index.
-    const positions = new Set([0, arr.length - 1]);
+    // so each is selected with an unambiguous index.
+    const positions = new Set();
     for (let i = 0; i < p.length; i++) {
         const idx = quantileIndex(arr.length, p[i]);
         positions.add(Math.floor(idx));
@@ -65,23 +65,19 @@ function multiQuantileSelect(arr, p) {
     }
     const indices = Array.from(positions).sort(compare);
 
-    // Recursively partition around the median requested position, then the two
-    // halves. The just-placed pivot is excluded from the child ranges so that a
-    // later, narrower quickselect cannot disturb an already-finalized position.
-    const stack = [0, indices.length - 1, 0, arr.length - 1];
-    while (stack.length) {
-        const right = stack.pop();
-        const left = stack.pop();
-        const r = stack.pop();
-        const l = stack.pop();
-        if (l > r) continue;
+    multiselect(arr, indices, 0, indices.length - 1, 0, arr.length - 1);
+}
 
-        const m = (l + r) >> 1;
-        quickselect(arr, indices[m], left, right);
-
-        stack.push(l, m - 1, left, indices[m] - 1);
-        stack.push(m + 1, r, indices[m] + 1, right);
-    }
+// Place every order statistic in `indices` by partitioning around the median
+// requested position, then recursing into the two halves. The just-placed pivot
+// is excluded from the child ranges (indices[mid] ± 1) so that a later, narrower
+// quickselect cannot disturb an already-finalized position.
+function multiselect(arr, indices, lo, hi, left, right) {
+    if (lo > hi) return;
+    const mid = (lo + hi) >> 1;
+    quickselect(arr, indices[mid], left, right);
+    multiselect(arr, indices, lo, mid - 1, left, indices[mid] - 1);
+    multiselect(arr, indices, mid + 1, hi, indices[mid] + 1, right);
 }
 
 function compare(a, b) {

--- a/test/quantile.test.js
+++ b/test/quantile.test.js
@@ -89,5 +89,73 @@ test("quantile", function (t) {
         }
     );
 
+    t.test(
+        "array of quantiles is independent of which quantiles are requested (#704)",
+        function (t) {
+            // Each quantile must equal the result of computing it on its own,
+            // regardless of the other quantiles requested alongside it.
+            const data = Object.freeze([
+                4534264.499853279, 0, 0, 4441655.968117084, 7982031.499157332,
+                11183760.330270268, 8374531.7466523405, 7537166.851276029,
+                6408451.109897822, 4858231.646338846, 6409803.519554875,
+                4296216.572964368, 5367514.3078208575, 6364913.420875475,
+                8621150.51996475, 9236261.500350267, 7850954.174512796,
+                6026897.449805159, 3569031.9331034794, 5336662.162307054,
+                6953168.388225255, 6789669.207787706, 6225885.17604323,
+                5217135.654872652, 6199349.484675659, 5858452.126622974
+            ]);
+            const ps = [0.0, 0.05, 0.95, 1.0];
+            t.same(
+                ss.quantile(data, ps),
+                ps.map((p) => ss.quantile(data, p))
+            );
+            t.end();
+        }
+    );
+
+    t.test(
+        "array of quantiles matches a full sort for tricky inputs",
+        function (t) {
+            // Regression for multiQuantileSelect: a narrow quickselect could
+            // disturb an already-finalized order statistic. Compare against a
+            // brute-force fully-sorted computation across duplicate-heavy data.
+            const quantileSorted = (sorted, p) => {
+                const idx = (sorted.length - 1) * p;
+                if (p === 1) return sorted[sorted.length - 1];
+                if (p === 0) return sorted[0];
+                const lower = Math.floor(idx);
+                const upper = Math.ceil(idx);
+                return (
+                    sorted[lower] +
+                    (idx - lower) * (sorted[upper] - sorted[lower])
+                );
+            };
+            const cases = [
+                {
+                    x: [
+                        31, 16, 67, 56, 16, 12, 79, 13, 3, 37, 41, 68, 3, 52,
+                        88, 55, 44, 7
+                    ],
+                    ps: [0.75, 0, 0.1, 0.95, 0.2]
+                },
+                {
+                    x: [
+                        9784654, 9784654, 1295491, 3093978, 5430034, 0, 9057878,
+                        4402670, 9734910, 4110841, 8156564, 2673582, 3841950
+                    ],
+                    ps: [0, 0.33, 0.5, 0.95, 1]
+                }
+            ];
+            for (const { x, ps } of cases) {
+                const sorted = x.slice().sort((a, b) => a - b);
+                t.same(
+                    ss.quantile(x, ps),
+                    ps.map((p) => quantileSorted(sorted, p))
+                );
+            }
+            t.end();
+        }
+    );
+
     t.end();
 });


### PR DESCRIPTION
multiQuantileSelect placed each requested order statistic with quickselect,
but its recursion handed fractional indices to child ranges and let a later,
narrower quickselect re-partition a range that still contained an
already-finalized position, corrupting it. As a result quantile(x, array)
could return a value for one quantile that differed from computing that
quantile on its own (e.g. quantile(data, [0, 0.05, 0.95, 1])[1] !==
quantile(data, 0.05)).

Reduce the requested quantiles to the distinct integer order statistics they
read (floor and ceil of each index, plus the endpoints), then select them with
a multiselect that excludes each placed pivot from its child ranges so a
finalized position is never disturbed.

Fixes #704