### PR TITLE
fix(wilcoxon): reset tied ranks between separate tie groups

### DIFF
--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -39,6 +39,7 @@ function wilcoxonRankSum(sampleX, sampleY) {
             }
         } else if (tiedRanks.length > 1) {
             replaceRanksInPlace(pooledSamples, tiedRanks);
+            tiedRanks = [pooledSamples[i].rank];
         } else {
             tiedRanks = [pooledSamples[i].rank];
         }

--- a/test/wilcoxon_rank_sum.test.js
+++ b/test/wilcoxon_rank_sum.test.js
@@ -38,6 +38,13 @@ describe("wilcoxonRankSum", function () {
         assert.equal(res, 6.5);
     });
 
+    it("multiple separate tied groups are handled correctly", function () {
+        const x = Object.freeze([1, 1]);
+        const y = Object.freeze([2, 2]);
+        const res = ss.wilcoxonRankSum(x, y);
+        assert.equal(res, 3);
+    });
+
     it("empty input throws", function () {
         const message = /Neither sample can be empty/;
         assert.throws(function () {


### PR DESCRIPTION
The tie averaging in `wilcoxonRankSum` reused the `tiedRanks` buffer when a value change closed a tie group. The buffer was averaged but never reset, so a later tie appended its ranks to the stale group and the average spanned unrelated positions. This shows up whenever the pooled sample has more than one tied group, for example `wilcoxonRankSum([1, 1], [2, 2])` returned 5 instead of 3.

The fix resets `tiedRanks` to the current element after averaging a closed group, matching the reset already done in the single-element branch. Adds a regression test for separate tied groups.
