### PR TITLE
fix(bayes): accumulate scores across all item properties

### DIFF
--- a/src/bayesian_classifier.js
+++ b/src/bayesian_classifier.js
@@ -83,8 +83,11 @@ class BayesianClassifier {
             const v = item[k];
             for (category in this.data) {
                 // Create an empty object for storing key - value combinations
-                // for this category.
-                odds[category] = {};
+                // for this category, keeping combinations already collected
+                // from earlier properties of the same item.
+                if (odds[category] === undefined) {
+                    odds[category] = {};
+                }
 
                 // If this item doesn't even have a property, it counts for nothing,
                 // but if it does have the property that we're looking for from

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -172,4 +172,31 @@ describe("BayesianClassifier", function () {
             }
         );
     });
+
+    it("sums the scores of every property in the item", function () {
+        const bayes = new BayesianClassifier();
+        bayes.train(
+            {
+                species: "Cat",
+                color: "white"
+            },
+            "animal"
+        );
+        bayes.train(
+            {
+                species: "Cat",
+                color: "black"
+            },
+            "animal"
+        );
+        assert.deepEqual(
+            bayes.score({
+                species: "Cat",
+                color: "white"
+            }),
+            {
+                animal: 1.5
+            }
+        );
+    });
 });


### PR DESCRIPTION
`BayesianClassifier.score` reset the per-category odds object on every property of the scored item, so all but the last property were discarded and multi-property items were scored on a single attribute. After training two `animal` items sharing `species: "Cat"` with different colors, scoring `{ species: "Cat", color: "white" }` returned `{ animal: 0.5 }` instead of `{ animal: 1.5 }`.

The fix initializes each category's odds object once per `score` call so every property contributes to the tallied sum. Existing single-property tests are unaffected. Adds a multi-property regression test.
