### PR TITLE
fix: discrete distributions no longer truncate on intermediate overflow

### DIFF
--- a/.changeset/discrete-pmf-overflow.md
+++ b/.changeset/discrete-pmf-overflow.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `poissonDistribution()` and `binomialDistribution()` returning a truncated table ending in `Infinity` or `NaN`. Both built each cell from a power and a factorial (or a binomial coefficient) that leave floating-point range long before their product does, so the cumulative-probability stopping rule was satisfied by a non-finite sum instead of by the distribution: `poissonDistribution(200)` returned 135 cells covering 0.000045% of the distribution, and `binomialDistribution(10000, 0.5)` returned 135 cells covering none of it. Cells are now taken through `gammaln`, and a table that cannot be completed returns `undefined` rather than a partial one.

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -1,4 +1,46 @@
 import epsilon from "./epsilon.js";
+import gammaln from "./gammaln.js";
+
+// A distribution over more trials than this would need a table we cannot
+// allocate. Past that we report a distribution we cannot produce rather than
+// a partial one.
+const maxCells = 1e6;
+
+/**
+ * The probability of exactly `x` successes, taken through its logarithm: the
+ * binomial coefficient and the two powers each leave floating-point range long
+ * before the product they form does, so computing them separately loses cells
+ * the distribution needs.
+ *
+ * @private
+ * @param {number} trials number of trials
+ * @param {number} probability probability of success in one trial
+ * @param {number} x number of successes
+ * @returns {number} probability of exactly `x` successes
+ */
+function probabilityOfSuccesses(trials, probability, x) {
+    // The logarithms below are undefined at the ends of the probability range,
+    // where the outcome is certain anyway.
+    if (probability === 0) {
+        if (x === 0) {
+            return 1;
+        }
+        return 0;
+    }
+    if (probability === 1) {
+        if (x === trials) {
+            return 1;
+        }
+        return 0;
+    }
+    return Math.exp(
+        gammaln(trials + 1) -
+            gammaln(x + 1) -
+            gammaln(trials - x + 1) +
+            x * Math.log(probability) +
+            (trials - x) * Math.log(1 - probability)
+    );
+}
 
 /**
  * The [Binomial Distribution](http://en.wikipedia.org/wiki/Binomial_distribution) is the discrete probability
@@ -26,23 +68,31 @@ function binomialDistribution(trials, probability) /*: ?number[] */ {
     let x = 0;
     let cumulativeProbability = 0;
     const cells = [];
-    let binomialCoefficient = 1;
+    // More successes than trials are impossible, and the table cannot outgrow
+    // what we can allocate.
+    const lastCell = Math.min(trials, maxCells - 1);
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
         // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function)
-        cells[x] =
-            binomialCoefficient *
-            Math.pow(probability, x) *
-            Math.pow(1 - probability, trials - x);
+        cells[x] = probabilityOfSuccesses(trials, probability, x);
         cumulativeProbability += cells[x];
         x++;
-        binomialCoefficient = (binomialCoefficient * (trials - x + 1)) / x;
         // when the cumulativeProbability is nearly 1, we've calculated
         // the useful range of this distribution
-    } while (cumulativeProbability < 1 - epsilon);
+    } while (cumulativeProbability < 1 - epsilon && x <= lastCell);
+
+    // Stopping for any other reason - a probability that is not a number, or
+    // more trials than the table can hold - leaves cells that do not add up to
+    // a distribution, so report that rather than returning them.
+    if (
+        Number.isNaN(cumulativeProbability) ||
+        cumulativeProbability < 1 - epsilon
+    ) {
+        return undefined;
+    }
 
     return cells;
 }

--- a/src/poisson_distribution.js
+++ b/src/poisson_distribution.js
@@ -1,4 +1,10 @@
 import epsilon from "./epsilon.js";
+import gammaln from "./gammaln.js";
+
+// The Poisson distribution has no upper bound, so cap the table at a length we
+// can still allocate. Past that we report a distribution we cannot produce
+// rather than a partial one.
+const maxCells = 1e6;
 
 /**
  * The [Poisson Distribution](http://en.wikipedia.org/wiki/Poisson_distribution)
@@ -26,20 +32,31 @@ function poissonDistribution(lambda) /*: ?number[] */ {
     let cumulativeProbability = 0;
     // the calculated cells to be returned
     const cells = [];
-    let factorialX = 1;
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
-        // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function)
-        cells[x] = (Math.exp(-lambda) * Math.pow(lambda, x)) / factorialX;
+        // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function),
+        // taken through its logarithm: `lambda` raised to `x` and the factorial
+        // of `x` each leave floating-point range long before their ratio does,
+        // so computing them separately loses cells the distribution needs.
+        cells[x] = Math.exp(x * Math.log(lambda) - lambda - gammaln(x + 1));
         cumulativeProbability += cells[x];
         x++;
-        factorialX *= x;
         // when the cumulativeProbability is nearly 1, we've calculated
         // the useful range of this distribution
-    } while (cumulativeProbability < 1 - epsilon);
+    } while (cumulativeProbability < 1 - epsilon && x < maxCells);
+
+    // Stopping for any other reason - a lambda that is not a number, or a
+    // distribution too wide for the table - leaves cells that do not add up to
+    // a distribution, so report that rather than returning them.
+    if (
+        Number.isNaN(cumulativeProbability) ||
+        cumulativeProbability < 1 - epsilon
+    ) {
+        return undefined;
+    }
 
     return cells;
 }

--- a/test/binomial_distribution.test.js
+++ b/test/binomial_distribution.test.js
@@ -48,6 +48,84 @@ describe("binomialDistribution", function () {
         );
     });
 
+    // The binomial coefficient and the two powers each leave floating-point
+    // range well before the distribution peaks, which used to end the table
+    // early on a cell of Infinity or NaN: binomialDistribution(1021, 0.5)
+    // returned 497 cells worth 19% of the distribution, and
+    // binomialDistribution(10000, 0.5) returned 135 cells worth none of it.
+    it("describes the whole distribution for a large number of trials", function () {
+        const cases = [
+            [1020, 0.5],
+            [1021, 0.5],
+            [2000, 0.5],
+            [10000, 0.5],
+            [10000, 0.999],
+            [100000, 0.001]
+        ];
+        for (const parameters of cases) {
+            const label = parameters[0] + ", " + parameters[1];
+            const cells = ss.binomialDistribution(parameters[0], parameters[1]);
+            assert.ok(
+                cells.every(Number.isFinite),
+                label + " has a cell that is not a number"
+            );
+            assert.ok(
+                ss.sum(cells) >= 1 - ss.epsilon,
+                label + " stops short of the distribution"
+            );
+            assert.ok(
+                cells.length <= parameters[0] + 1,
+                label + " runs past the last possible outcome"
+            );
+        }
+    });
+
+    it("peaks at the mean for a large number of trials", function () {
+        const cells = ss.binomialDistribution(10000, 0.5);
+        assert.equal(cells.indexOf(ss.max(cells)), 5000);
+    });
+
+    // Reference cells evaluated at 50 significant digits with mpmath and
+    // cross-checked against scipy.stats.binom.pmf.
+    it("matches reference cells for a large number of trials", function () {
+        const references = [
+            [1021, 0.5, 510, 0.024952173249668672],
+            [2000, 0.5, 900, 8.0046118774649461e-7],
+            [2000, 0.5, 1000, 0.01783901114585432],
+            [10000, 0.5, 5000, 0.0079786461393821541],
+            [100000, 0.001, 50, 1.2082375507591476e-8],
+            [100000, 0.001, 100, 0.039880942234625599]
+        ];
+        for (const reference of references) {
+            const cells = ss.binomialDistribution(reference[0], reference[1]);
+            assert.ok(
+                ss.approxEqual(cells[reference[2]], reference[3], 1e-8),
+                reference[0] +
+                    ", " +
+                    reference[1] +
+                    " at " +
+                    reference[2] +
+                    ": " +
+                    cells[reference[2]] +
+                    " != " +
+                    reference[3]
+            );
+        }
+    });
+
+    it("keeps the certain outcomes at the ends of the probability range", function () {
+        assert.deepEqual(ss.binomialDistribution(10, 0), [1]);
+        const allSuccesses = ss.binomialDistribution(10, 1);
+        assert.equal(allSuccesses.length, 11);
+        assert.equal(allSuccesses[10], 1);
+        assert.equal(ss.sum(allSuccesses), 1);
+    });
+
+    it("can return undefined when the distribution cannot be tabulated", function () {
+        assert.equal(undefined, ss.binomialDistribution(5, Number.NaN));
+        assert.equal(undefined, ss.binomialDistribution(1e9, 0.5));
+    });
+
     it("can return null when p or n are not valid parameters", function () {
         assert.equal(
             ss.binomialDistribution(0, 0.5),

--- a/test/poisson_distribution.test.js
+++ b/test/poisson_distribution.test.js
@@ -29,4 +29,68 @@ describe("poissonDistribution", function () {
         assert.equal(undefined, ss.poissonDistribution(0));
         assert.equal(undefined, ss.poissonDistribution(-10));
     });
+
+    // lambda ^ x and x! both leave floating-point range well before the
+    // distribution peaks, which used to end the table early on a cell of
+    // Infinity or NaN: lambda = 200 returned 135 cells worth 0.000045% of the
+    // distribution, and lambda = 1000 returned 104 cells worth none of it.
+    it("describes the whole distribution for a large lambda", function () {
+        for (const lambda of [1, 50, 110, 111, 150, 200, 745, 746, 1000]) {
+            const cells = ss.poissonDistribution(lambda);
+            assert.ok(
+                cells.every(Number.isFinite),
+                "lambda " + lambda + " has a cell that is not a number"
+            );
+            assert.ok(
+                ss.sum(cells) >= 1 - ss.epsilon,
+                "lambda " + lambda + " stops short of the distribution"
+            );
+            assert.ok(
+                cells.length > lambda,
+                "lambda " + lambda + " stops before its own mean"
+            );
+        }
+    });
+
+    it("peaks at the mean for a large lambda", function () {
+        const cells = ss.poissonDistribution(200);
+        assert.equal(cells.indexOf(ss.max(cells)), 199);
+    });
+
+    // Reference cells evaluated at 50 significant digits with mpmath and
+    // cross-checked against scipy.stats.poisson.pmf.
+    it("matches reference cells for a large lambda", function () {
+        const references = [
+            [111, 111, 0.03783750840195968],
+            [150, 150, 0.032555409456836548],
+            [200, 134, 1.5122660970724418e-7],
+            [200, 199, 0.028197727685920822],
+            [746, 746, 0.014604683118189346],
+            [1000, 900, 7.5169543521259519e-5],
+            [1000, 1000, 0.012614611348721499]
+        ];
+        for (const reference of references) {
+            const cells = ss.poissonDistribution(reference[0]);
+            assert.ok(
+                ss.approxEqual(cells[reference[1]], reference[2], 1e-9),
+                "lambda " +
+                    reference[0] +
+                    " at " +
+                    reference[1] +
+                    ": " +
+                    cells[reference[1]] +
+                    " != " +
+                    reference[2]
+            );
+        }
+    });
+
+    it("can return undefined when the distribution cannot be tabulated", function () {
+        assert.equal(undefined, ss.poissonDistribution(Number.NaN));
+        assert.equal(
+            undefined,
+            ss.poissonDistribution(Number.POSITIVE_INFINITY)
+        );
+        assert.equal(undefined, ss.poissonDistribution(1e9));
+    });
 });


### PR DESCRIPTION
`poissonDistribution` and `binomialDistribution` return a table that stops short of its own mean and ends on a non-finite cell, for arguments well inside their documented domain:

```js
const cells = ss.poissonDistribution(200);
cells.length; // 135, and the distribution peaks at 200
cells[134]; // Infinity
ss.sum(cells); // NaN - the finite cells are 0.000045% of the distribution

ss.binomialDistribution(10000, 0.5); // 135 cells, all zero except a final NaN
```

The first failing arguments are `lambda >= 111` and, at `p = 0.5`, `trials >= 1021`. Nothing is thrown and `undefined` (the documented invalid-input signal) is not returned, because the input is valid.

## Root cause

Both functions build each cell from factors that leave floating-point range long before the cell itself does: `Math.pow(lambda, x) / factorialX` for Poisson, `binomialCoefficient * Math.pow(probability, x) * Math.pow(1 - probability, trials - x)` for binomial. `Math.pow(200, 134)` is `Infinity` while the probability it belongs to is 1.5e-7. Past `lambda = 745` the leading `Math.exp(-lambda)` underflows to zero as well, so the cell is `0 * Infinity`, i.e. `NaN`.

Both loops then share this stopping rule:

```js
} while (cumulativeProbability < 1 - epsilon);
```

`Infinity < 0.9999` and `NaN < 0.9999` are both false, so the overflow *is* the exit condition. The loop reports that it covered the distribution and hands back the truncated table.

## Extent

I swept both functions against `scipy.stats` (checked in turn against mpmath at 50 digits, and against the Hines & Montgomery values the tests already pin) over 28 values of `lambda` and 124 `(trials, probability)` pairs. Counting a table as wrong if it holds a non-finite cell or covers less than `1 - epsilon` of the distribution: **14/28 Poisson and 44/124 binomial before, 0 and 0 after.**

| call | cells returned | share of the distribution | mode |
| --- | --- | --- | --- |
| `poissonDistribution(150)` | 143 | 27% | 150 |
| `poissonDistribution(200)` | 135 | 0.000045% | 200 |
| `poissonDistribution(1000)` | 104 | 5.7e-288% | 1000 |
| `binomialDistribution(1021, 0.5)` | 497 | 19% | 511 |
| `binomialDistribution(2000, 0.5)` | 229 | 4.2e-294% | 1000 |
| `binomialDistribution(10000, 0.5)` | 135 | 0% | 5000 |
| `binomialDistribution(1000000, 0.0001)` | 68 | 0.029% | 100 |

`bernoulliDistribution` is a closed form and is unaffected. `chiSquaredGoodnessOfFit` calls `poissonDistribution` and inherits the truncated table for any sample with a mean of 111 or more.

## Fix

Each cell is taken through its logarithm using `gammaln`, which the library already ships and exports for exactly this problem ("useful for values of n too large for the normal gamma function"):

```js
// poisson
Math.exp(x * Math.log(lambda) - lambda - gammaln(x + 1));

// binomial
Math.exp(
    gammaln(trials + 1) - gammaln(x + 1) - gammaln(trials - x + 1) +
        x * Math.log(probability) + (trials - x) * Math.log(1 - probability)
);
```

The cumulative probability is now checked after the loop rather than trusted: a table that did not reach `1 - epsilon` is not a distribution, so `undefined` is returned instead of part of one. That also covers `poissonDistribution(NaN)` and `binomialDistribution(5, NaN)`, which used to return `[NaN]` — `NaN` slips through the existing input checks.

The loops need a bound now that they run all the way to the mode. `binomialDistribution` stops after `trials`, since more successes than trials are impossible, and both stop at a million cells: `poissonDistribution(1e9)` would otherwise try to build a billion-cell array, and instead returns `undefined` in about 20ms. `poissonDistribution(900000)` still returns its full 903531-cell table.

## Accuracy

Evaluating cells independently through logarithms gives up some precision where the product form worked. Worst relative error against the oracle, before -> after: `lambda <= 110`, 1.8e-13 -> 2.3e-13; `binomialDistribution(1000, 0.5)`, 1.1e-13 -> 1.6e-12; `binomialDistribution(10000, 0.001)`, 1.9e-14 -> 1.7e-11. Everything past those points used to be a truncated table and is now good to 4e-9 or better at a million trials. The worst of it is seven orders of magnitude inside the `epsilon` these functions already use as their stopping rule.

## Tests

Nine cases across the two test files, all failing on `main` except the `probability` 0 and 1 pin, which is there to hold the existing degenerate output. They cover: every cell finite and the table summing to at least `1 - epsilon`, for nine values of `lambda` and six `(trials, probability)` pairs; the peak landing at the mean for `poissonDistribution(200)` and `binomialDistribution(10000, 0.5)`; thirteen reference cells computed at 50 digits with mpmath and cross-checked against `scipy.stats`; and the `undefined` cases. Full suite 287 passing, `biome` and `documentation lint` clean.
