### PR TITLE
fix: chiSquaredGoodnessOfFit no longer reports a fit it never measured

### DIFF
--- a/.changeset/chi-squared-unchecked-lookups.md
+++ b/.changeset/chi-squared-unchecked-lookups.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `chiSquaredGoodnessOfFit()` reporting a fit it never measured. Collapsing a sparse class dropped the last class instead of the one that had just been merged, so observations were discarded and others double counted; an observation past the end of the hypothesized distribution had no expected frequency at all, which made the statistic `NaN`; and `criticalValue < NaN` is `false`, the same answer the function gives for a good fit. Degrees of freedom and significance levels the table does not cover now raise a descriptive error instead of a `TypeError` or a silent `false`.

--- a/src/chi_squared_goodness_of_fit.js
+++ b/src/chi_squared_goodness_of_fit.js
@@ -68,16 +68,37 @@ function chiSquaredGoodnessOfFit(data, distributionType, significance) {
         }
     }
 
+    if (expectedFrequencies.length === 0) {
+        throw new Error(
+            "chiSquaredGoodnessOfFit requires distributionType to return a distribution for the mean of the data"
+        );
+    }
+
+    // The hypothesized distribution can stop short of the largest observation,
+    // leaving those observations with no expected frequency to be compared
+    // against. Fold them into the last class the distribution does cover, the
+    // same treatment the collapse below gives to sparse classes, so that the
+    // two histograms describe the same classes.
+    const lastClass = expectedFrequencies.length - 1;
+    for (let k = observedFrequencies.length - 1; k > lastClass; k--) {
+        observedFrequencies[lastClass] += observedFrequencies[k];
+        observedFrequencies.pop();
+    }
+
     // Working backward through the expected frequencies, collapse classes
     // if less than three observations are expected for a class.
     // This transformation is applied to the observed frequencies as well.
-    for (let k = expectedFrequencies.length - 1; k >= 0; k--) {
+    // The class that was merged is the one that has to go: popping instead
+    // drops the last class, which is only the same thing until a class is
+    // large enough to keep. The first class is left alone, since there is no
+    // class before it to collapse it into.
+    for (let k = expectedFrequencies.length - 1; k >= 1; k--) {
         if (expectedFrequencies[k] < 3) {
             expectedFrequencies[k - 1] += expectedFrequencies[k];
-            expectedFrequencies.pop();
+            expectedFrequencies.splice(k, 1);
 
             observedFrequencies[k - 1] += observedFrequencies[k];
-            observedFrequencies.pop();
+            observedFrequencies.splice(k, 1);
         }
     }
 
@@ -89,15 +110,37 @@ function chiSquaredGoodnessOfFit(data, distributionType, significance) {
             expectedFrequencies[k];
     }
 
+    if (!Number.isFinite(chiSquared)) {
+        throw new Error(
+            "chiSquaredGoodnessOfFit could not compute a test statistic for this data and distribution"
+        );
+    }
+
     // Calculate degrees of freedom for this test and look it up in the
     // `chiSquaredDistributionTable` in order to
     // accept or reject the goodness-of-fit of the hypothesized distribution.
     // Degrees of freedom, calculated as (number of class intervals -
     // number of hypothesized distribution parameters estimated - 1)
     const degreesOfFreedom = observedFrequencies.length - c - 1;
-    return (
-        chiSquaredDistributionTable[degreesOfFreedom][significance] < chiSquared
-    );
+    if (degreesOfFreedom < 1) {
+        throw new Error(
+            "chiSquaredGoodnessOfFit requires more data: the classes that survive collapsing leave no degrees of freedom"
+        );
+    }
+
+    const criticalValues = chiSquaredDistributionTable[degreesOfFreedom];
+    if (criticalValues === undefined) {
+        throw new Error(
+            `chiSquaredGoodnessOfFit has no critical values tabulated for ${degreesOfFreedom} degrees of freedom`
+        );
+    }
+    if (criticalValues[significance] === undefined) {
+        throw new Error(
+            `chiSquaredGoodnessOfFit has no critical value tabulated for a significance of ${significance}`
+        );
+    }
+
+    return criticalValues[significance] < chiSquared;
 }
 
 export default chiSquaredGoodnessOfFit;

--- a/test/chi_squared_goodness_of_fit.test.js
+++ b/test/chi_squared_goodness_of_fit.test.js
@@ -33,4 +33,161 @@ describe("chiSquaredGoodnessOfFit", function () {
             )
         );
     });
+
+    // Samples written as [value, count] pairs to keep them readable.
+    function sample(pairs) {
+        const data = [];
+        for (const [value, count] of pairs) {
+            for (let i = 0; i < count; i++) {
+                data.push(value);
+            }
+        }
+        return data;
+    }
+
+    // An observation past the last cell of the hypothesized distribution had no
+    // expected frequency to be compared against, so the statistic came out NaN
+    // and `criticalValue < NaN` reported the data as a fit.
+    it("counts observations that fall outside the hypothesized distribution", function () {
+        const observations = sample([
+            [0, 25],
+            [1, 10],
+            [2, 10],
+            [3, 10],
+            [4, 5]
+        ]);
+        // p = 1.45e-4 without the outlier and 2.98e-6 with it, so a sample that
+        // is already a poor fit cannot become a good one by gaining an outlier.
+        assert.equal(
+            ss.chiSquaredGoodnessOfFit(
+                observations,
+                ss.poissonDistribution,
+                0.05
+            ),
+            true
+        );
+        assert.equal(
+            ss.chiSquaredGoodnessOfFit(
+                observations.concat([30]),
+                ss.poissonDistribution,
+                0.05
+            ),
+            true
+        );
+    });
+
+    // Collapsing a class dropped the last class rather than the one that had
+    // just been merged, which discarded observations and double counted others
+    // as soon as one class was large enough to keep.
+    it("keeps every observation when collapsing classes", function () {
+        // 60 observations, chi-squared 9.2635 on 6 degrees of freedom, p = 0.159.
+        const observations = sample([
+            [2, 3],
+            [3, 14],
+            [4, 14],
+            [5, 12],
+            [6, 10],
+            [7, 4],
+            [8, 2],
+            [9, 1]
+        ]);
+        assert.equal(
+            ss.chiSquaredGoodnessOfFit(
+                observations,
+                ss.poissonDistribution,
+                0.1
+            ),
+            false
+        );
+    });
+
+    it("throws when the data leaves no degrees of freedom", function () {
+        assert.throws(function () {
+            ss.chiSquaredGoodnessOfFit(
+                [7, 7, 7, 7, 7, 7, 7, 7, 7, 7],
+                ss.poissonDistribution,
+                0.05
+            );
+        }, /degrees of freedom/);
+    });
+
+    it("throws for degrees of freedom the table does not cover", function () {
+        const observations = [];
+        for (let value = 0; value <= 120; value++) {
+            for (let i = 0; i < 40; i++) {
+                observations.push(value);
+            }
+        }
+        assert.throws(function () {
+            ss.chiSquaredGoodnessOfFit(
+                observations,
+                ss.poissonDistribution,
+                0.05
+            );
+        }, /no critical values tabulated/);
+    });
+
+    // The table has columns for eleven significance levels. Any other one read
+    // as undefined, and `undefined < chiSquared` reported the data as a fit.
+    it("throws for a significance level the table does not cover", function () {
+        assert.throws(function () {
+            ss.chiSquaredGoodnessOfFit(data1019, ss.poissonDistribution, 0.075);
+        }, /significance/);
+    });
+
+    it("throws when the distribution cannot be built for the mean", function () {
+        // binomialDistribution takes two parameters and returns undefined here.
+        assert.throws(function () {
+            ss.chiSquaredGoodnessOfFit(data1019, ss.binomialDistribution, 0.05);
+        }, /distributionType/);
+        assert.throws(function () {
+            ss.chiSquaredGoodnessOfFit(data1019, () => [0, 0, 0, 0], 0.05);
+        }, /test statistic/);
+    });
+
+    // Critical values fall as the significance level rises, so a sample that is
+    // rejected at one level has to stay rejected at every larger one. The levels
+    // between the table's columns have to be refused rather than answered.
+    it("gives a verdict that is monotone in the significance level", function () {
+        const significances = [
+            0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.2, 0.5, 0.9, 0.95, 0.975,
+            0.99, 0.995
+        ];
+        const samples = [
+            data1019,
+            [0, 2, 3, 7, 7, 7, 7, 7, 7, 9, 10],
+            sample([
+                [2, 3],
+                [3, 14],
+                [4, 14],
+                [5, 12],
+                [6, 10],
+                [7, 4],
+                [8, 2],
+                [9, 1]
+            ])
+        ];
+        for (const observations of samples) {
+            let rejected = false;
+            for (const significance of significances) {
+                let verdict;
+                try {
+                    verdict = ss.chiSquaredGoodnessOfFit(
+                        observations,
+                        ss.poissonDistribution,
+                        significance
+                    );
+                } catch {
+                    // Not one of the table's significance levels.
+                    continue;
+                }
+                assert.equal(
+                    verdict || !rejected,
+                    true,
+                    `rejected below ${significance} but not at it`
+                );
+                rejected = rejected || verdict;
+            }
+        }
+    });
 });


### PR DESCRIPTION
`chiSquaredGoodnessOfFit` reports a fit whenever its arithmetic produces `NaN`, because `criticalValue < NaN` is `false` — the same answer a good fit gives. Two things produce that `NaN`: collapsing a sparse class pops the last class instead of the one just merged, which discards observations and double counts others (six of eleven disappear; five survive on this suite's own "gaps" fixture), and an observation past the end of the hypothesized distribution has no expected frequency to pair with. A significance level outside the table's eleven columns reads as `undefined` and reports a fit too, and degrees of freedom outside the table threw a `TypeError`.

```js
// 25 zeros, 10 ones, 10 twos, 10 threes, 5 fours
ss.chiSquaredGoodnessOfFit(data, ss.poissonDistribution, 0.05);              // true, rejects
ss.chiSquaredGoodnessOfFit(data.concat([30]), ss.poissonDistribution, 0.05); // false, accepts
```

One extreme outlier is stronger evidence against Poisson, not weaker (exact p goes from 1.5e-4 to 3.0e-6), and it flipped the verdict to "fits".

Observations past the distribution now fold into its last class, the collapse removes the class it merged, and a lookup the table cannot answer raises a descriptive error. The three existing fixtures keep their values; I checked the corrected statistics against exact chi-squared p-values computed with mpmath. 285 tests passing.