### PR TITLE
fix(rank-correlation): give tied values midranks

### DIFF
--- a/.changeset/rank-correlation-midranks.md
+++ b/.changeset/rank-correlation-midranks.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `sampleRankCorrelation` returning different results for the same data depending on the order the pairs are listed in. Tied values were given distinct consecutive ranks broken by original array position, rather than sharing the average of the ranks they span as Spearman's rho requires. Reordering rows could change the magnitude and even the sign of the result. Tied values now receive midranks, so the correlation depends only on the paired data. As a consequence an input with no rank variance — every value tied — now correctly returns `NaN` instead of reporting near-perfect correlation. Results for inputs with no ties are unchanged.

--- a/src/sample_rank_correlation.js
+++ b/src/sample_rank_correlation.js
@@ -1,34 +1,57 @@
 import sampleCorrelation from "./sample_correlation.js";
 
 /**
+ * Rank values, giving tied values the average of the ranks they span.
+ *
+ * Spearman's rho is defined on these midranks. Assigning tied values
+ * distinct consecutive ranks instead would make the rank of a value depend
+ * on where it happens to sit in the input array, and therefore make the
+ * correlation depend on the order the pairs are listed in.
+ *
+ * @private
+ * @param {Array<number>} values input
+ * @returns {Array<number>} ranks, in the order of the input
+ */
+function midranks(values) {
+    const order = values
+        .map((value, index) => [value, index])
+        .sort((a, b) => a[0] - b[0]);
+
+    const ranks = Array(values.length);
+    let i = 0;
+    while (i < order.length) {
+        // Extend j across every value tied with the one at i.
+        let j = i;
+        while (j + 1 < order.length && order[j + 1][0] === order[i][0]) {
+            j++;
+        }
+        const rank = (i + j) / 2;
+        for (let k = i; k <= j; k++) {
+            ranks[order[k][1]] = rank;
+        }
+        i = j + 1;
+    }
+    return ranks;
+}
+
+/**
  * The [rank correlation](https://en.wikipedia.org/wiki/Rank_correlation) is
  * a measure of the strength of monotonic relationship between two arrays
+ *
+ * Tied values share the average of the ranks they span, so the result
+ * depends only on the paired data and not on the order the pairs are given
+ * in. When either input has no rank variance the correlation is undefined
+ * and the result is `NaN`.
  *
  * @param {Array<number>} x first input
  * @param {Array<number>} y second input
  * @returns {number} sample rank correlation
+ * @example
+ * sampleRankCorrelation([1, 2, 3, 4, 5], [1, 4, 9, 16, 25]);
+ * // => 1
  */
 function sampleRankCorrelation(x, y) {
-    const xIndexes = x
-        .map((value, index) => [value, index])
-        .sort((a, b) => a[0] - b[0])
-        .map((pair) => pair[1]);
-    const yIndexes = y
-        .map((value, index) => [value, index])
-        .sort((a, b) => a[0] - b[0])
-        .map((pair) => pair[1]);
-
-    // At this step, we have an array of indexes
-    // that map from sorted numbers to their original indexes. We reverse
-    // that so that it is an array of the sorted destination index.
-    const xRanks = Array(xIndexes.length);
-    const yRanks = Array(xIndexes.length);
-    for (let i = 0; i < xIndexes.length; i++) {
-        xRanks[xIndexes[i]] = i;
-        yRanks[yIndexes[i]] = i;
-    }
-
-    return sampleCorrelation(xRanks, yRanks);
+    return sampleCorrelation(midranks(x), midranks(y));
 }
 
 export default sampleRankCorrelation;

--- a/test/sample_rank_correlation.test.js
+++ b/test/sample_rank_correlation.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as ss from "../index.js";
+
+describe("sample rank correlation with tied values", function () {
+    it("does not depend on the order the pairs are listed in", function () {
+        // The same three paired observations {(1,1), (1,2), (2,1)}, with the
+        // first two rows swapped. A correlation is a property of the pairs,
+        // so both orderings must agree.
+        const first = ss.sampleRankCorrelation([1, 1, 2], [1, 2, 1]);
+        const second = ss.sampleRankCorrelation([1, 1, 2], [2, 1, 1]);
+        assert.ok(
+            Math.abs(first - second) < ss.epsilon,
+            `orderings disagree: ${first} vs ${second}`
+        );
+    });
+
+    it("gives tied values the average of the ranks they span", function () {
+        // x ranks as [0.5, 0.5, 2] and y as [0.5, 2, 0.5], whose correlation
+        // works out to exactly -0.5.
+        const rankCorr = ss.sampleRankCorrelation([1, 1, 2], [1, 2, 1]);
+        assert.ok(
+            Math.abs(rankCorr - -0.5) < ss.epsilon,
+            `expected -0.5, got ${rankCorr}`
+        );
+    });
+
+    it("is zero when ties leave no monotonic association", function () {
+        // Both variables rank as two tied pairs, arranged so that every
+        // increase in one is matched by a decrease in the other.
+        const rankCorr = ss.sampleRankCorrelation([1, 1, 2, 2], [1, 2, 1, 2]);
+        assert.ok(
+            Math.abs(rankCorr) < ss.epsilon,
+            `expected 0, got ${rankCorr}`
+        );
+    });
+
+    it("is not a number when an input has no rank variance", function () {
+        // Every y is tied, so its ranks are constant and rho is undefined.
+        assert.ok(
+            Number.isNaN(ss.sampleRankCorrelation([1, 2, 3, 4], [5, 5, 5, 5]))
+        );
+    });
+
+    it("is unchanged by reordering a larger tied dataset", function () {
+        const x = Object.freeze([1, 1, 2, 2, 3, 3]);
+        const y = Object.freeze([1, 2, 2, 3, 1, 3]);
+        const expected = ss.sampleRankCorrelation(x, y);
+        const orderings = [
+            [5, 4, 3, 2, 1, 0],
+            [1, 0, 3, 2, 5, 4],
+            [2, 4, 0, 5, 1, 3],
+            [3, 1, 4, 0, 2, 5]
+        ];
+        for (const order of orderings) {
+            const rankCorr = ss.sampleRankCorrelation(
+                order.map((i) => x[i]),
+                order.map((i) => y[i])
+            );
+            assert.ok(
+                Math.abs(rankCorr - expected) < ss.epsilon,
+                `reordering changed the result: ${rankCorr} vs ${expected}`
+            );
+        }
+    });
+
+    it("still reports perfect correlation for a monotonic tie-free input", function () {
+        const rankCorr = ss.sampleRankCorrelation(
+            [1, 2, 3, 4],
+            [10, 20, 30, 40]
+        );
+        assert.ok(
+            Math.abs(rankCorr - 1) < ss.epsilon,
+            `expected 1, got ${rankCorr}`
+        );
+    });
+});


### PR DESCRIPTION
Closes #813.

## Summary

`sampleRankCorrelation` returned a different value for the same paired data depending on the order the pairs were listed in, whenever either input contained ties. Swapping two rows of a three-pair dataset flipped the sign; across the 720 orderings of one six-pair dataset it produced 16 distinct values. Ranking both inputs with midranks makes the statistic a property of the pairs, as Spearman's rho is defined to be.

## The cause

Lines 26–29 assigned each value its position in the sorted array as its rank:

```js
for (let i = 0; i < xIndexes.length; i++) {
    xRanks[xIndexes[i]] = i;
    yRanks[yIndexes[i]] = i;
}
```

Tied values got distinct consecutive ranks, and since `Array.prototype.sort` is stable the tiebreak was the value's original index — so the rank of a tied value was a function of where it sat in the input array. Spearman's rho is defined on midranks, where tied values share the average of the ranks they span.

## Changes

- `src/sample_rank_correlation.js` — a private `midranks` helper walks the sorted pairs, extends a run across each group of equal values, and assigns that group the average of the ranks it spans. `sampleRankCorrelation` now ranks each input through it. No change to the public API surface.
- `test/sample_rank_correlation.test.js` — new; the function had no dedicated test file.
- `.changeset/rank-correlation-midranks.md` — patch.

Two further symptoms fall out of the same fix rather than needing separate handling:

- An input with no rank variance (every value tied) now returns `NaN`, where it previously reported `1.0000000000000002`. Ranking to a constant vector gives zero standard deviation, and `sampleCorrelation` divides by it. Reporting near-perfect monotonic association for a constant column seemed the most harmful of the symptoms.
- A length mismatch now reaches `sampleCovariance`'s own "requires samples with equal lengths" error. Previously both rank arrays were sized `Array(xIndexes.length)`, so a shorter `y` left holes and the function returned `NaN` silently.

## Deliberately unchanged

Ranks stay 0-based, as before — correlation is invariant under the affine shift to 1-based ranks, and keeping the existing convention makes the diff smaller. I also left `sampleCorrelation` and `rSquared` alone; both have their own unguarded-division edge cases, but those are separate contracts and did not belong in this change.

## Testing

`pnpm test` (typecheck, biome, `documentation lint`, and the full suite) on Node v24.18.0, Windows 11:

```
ℹ tests 284
ℹ suites 74
ℹ pass 284
ℹ fail 0
```

278 before, 284 after — the six added here.

The new tests fail against the current `main` and pass with this change. Verified by stashing only `src/sample_rank_correlation.js` and running the new file against the unmodified source:

```
✖ is unchanged by reordering a larger tied dataset
  AssertionError: reordering changed the result: -0.2571428571428572 vs 0.6571428571428571
```

The existing R-validated case in `test/sample_correlation.test.js` (`cor(x, y, method = "spearman")` = 0.6484848) still passes, which is the guard that tie-free behaviour is unchanged — that dataset has no ties, so its midranks are identical to the old ranks.

I checked the results against a midrank Spearman I implemented separately rather than against remembered reference values; the expected numbers in the tests (−0.5 for the three-pair case, exactly 0 for `[1,1,2,2]` vs `[1,2,1,2]`) are derivable by hand from the midrank vectors, and I have shown that derivation in the test comments so they can be checked without running anything.

One note on running the suite from Windows: `pnpm test` fails at the biome step on a default Git for Windows clone, because `core.autocrlf` is `true`, there is no `.gitattributes`, and biome flags all 270 files for `␍`. CI is `ubuntu-latest` only so it never sees this. Cloning with `git -c core.autocrlf=false clone` avoids it. Unrelated to this change, but I would happily send a one-line `.gitattributes` separately if that is wanted.
