### PR TITLE
fix(wilcoxon): reset tied ranks between separate tie groups

### DIFF
--- a/.changeset/cool-hats-brake.md
+++ b/.changeset/cool-hats-brake.md
@@ -1,0 +1,8 @@
+---
+"simple-statistics": patch
+---
+
+Fix wilcoxon rank-sum test behavior
+
+This fixes a bug in which the tie averaging in `wilcoxonRankSum` was
+incorrect and would return an unrelated position.

--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -39,6 +39,7 @@ function wilcoxonRankSum(sampleX, sampleY) {
             }
         } else if (tiedRanks.length > 1) {
             replaceRanksInPlace(pooledSamples, tiedRanks);
+            tiedRanks = [pooledSamples[i].rank];
         } else {
             tiedRanks = [pooledSamples[i].rank];
         }

--- a/src/wilcoxon_rank_sum.js
+++ b/src/wilcoxon_rank_sum.js
@@ -37,10 +37,10 @@ function wilcoxonRankSum(sampleX, sampleY) {
             if (i === pooledSamples.length - 1) {
                 replaceRanksInPlace(pooledSamples, tiedRanks);
             }
-        } else if (tiedRanks.length > 1) {
-            replaceRanksInPlace(pooledSamples, tiedRanks);
-            tiedRanks = [pooledSamples[i].rank];
         } else {
+            if (tiedRanks.length > 1) {
+                replaceRanksInPlace(pooledSamples, tiedRanks);
+            }
             tiedRanks = [pooledSamples[i].rank];
         }
     }

--- a/test/wilcoxon_rank_sum.test.js
+++ b/test/wilcoxon_rank_sum.test.js
@@ -38,6 +38,13 @@ describe("wilcoxonRankSum", function () {
         assert.equal(res, 6.5);
     });
 
+    it("multiple separate tied groups are handled correctly", function () {
+        const x = Object.freeze([1, 1]);
+        const y = Object.freeze([2, 2]);
+        const res = ss.wilcoxonRankSum(x, y);
+        assert.equal(res, 3);
+    });
+
     it("empty input throws", function () {
         const message = /Neither sample can be empty/;
         assert.throws(function () {


### PR DESCRIPTION
The tie averaging in wilcoxonRankSum reused the tiedRanks buffer when a
value change closed a tie group. Because the buffer was averaged but not
reset, a later tie appended its ranks to the stale group, so the average
spanned unrelated positions and every affected rank was wrong.

Reset tiedRanks to the current element after averaging a closed group,
matching the reset already done for the single-element branch.

---

This is a minor branch that:

- Does a minor code refactoring, behavior-preserving
- Adds a changeset