### PR TITLE
build: normalise line endings to LF so Windows clones can lint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Closes #815 — https://github.com/simple-statistics/simple-statistics/issues/815

## Summary

On a default Windows clone, `npm test` fails before a single test runs: biome reports a `␍` error on every tracked file. Since `test` is `lint && node --test`, the lint gate short-circuits and the suite never executes. You noted on the issue that `.gitattributes` is probably the more direct solution than setting biome's `lineEnding` to `auto`, so that's what this does.

## Changes

- Add `.gitattributes` containing `* text=auto eol=lf`

One line, one file. The index already stores LF, so this is not a tree-wide rewrite — `git add --renormalize .` reports zero modified files. It only changes what lands in the *working tree* on checkout.

## Why this rather than biome's `lineEnding`

`eol=lf` fixes the checkout itself, so every LF-expecting tool in the repo benefits at once — biome today, and `documentation lint`, `tsc`, or anything added later without each needing its own line-ending setting. Setting `lineEnding: auto` would make biome tolerate CRLF instead, leaving the working tree inconsistent with what CI produces.

`text=auto` keeps git's binary auto-detection, so a future binary file is still left alone. There are currently no `.bat`/`.cmd`/`.ps1` files or tracked binaries in the repo, so nothing needs an exemption.

## Deliberately unchanged

- No source, test, or config file is touched
- No changeset: `.gitattributes` doesn't ship in the published package and changes no library behavior, so no version bump is warranted
- `.github/workflows/nodejs.yml` still runs `ubuntu-latest` only. Adding a Windows leg to the matrix would have caught this and would stop it regressing, but that's a CI-policy call and a separate PR if you want it.

## Testing

Windows 11, Node v24.18.0, pnpm 11.17.0, `core.autocrlf=true` from the system config — the configuration in the issue.

Before, on `main` at `0779f22`:

```
$ pnpm exec biome check index.js src test
Checked 270 files in 291ms. No fixes applied.
Found 270 errors.
  × Some errors were emitted while running checks.
exit 1
```

After, same clone with `.gitattributes` added and the working tree re-checked-out:

```
$ git ls-files --eol -- package.json src/mean.js index.js
i/lf    w/lf    attr/text=auto eol=lf   index.js
i/lf    w/lf    attr/text=auto eol=lf   package.json
i/lf    w/lf    attr/text=auto eol=lf   src/mean.js

$ pnpm test
ℹ tests 285
ℹ suites 74
ℹ pass 285
ℹ fail 0
exit 0
```

Full `pnpm test` — `tsc --noEmit`, `biome check`, `documentation lint`, then the node runner — all green.

One limit worth stating: existing Windows clones won't pick this up from a plain `git pull`, because the attribute only applies on checkout. Anyone already affected needs `git rm -r --cached . && git reset --hard` once (or a fresh clone). Fresh clones after this merges are correct with no action.