### PR TITLE
discrete distributions no longer truncate

### DIFF
--- a/.changeset/discrete-pmf-overflow.md
+++ b/.changeset/discrete-pmf-overflow.md
@@ -1,5 +1,11 @@
 ---
-"simple-statistics": patch
+"simple-statistics": minor
 ---
 
 Fix `poissonDistribution()` and `binomialDistribution()` returning a truncated table ending in `Infinity` or `NaN`. Both built each cell from a power and a factorial (or a binomial coefficient) that leave floating-point range long before their product does, so the cumulative-probability stopping rule was satisfied by a non-finite sum instead of by the distribution: `poissonDistribution(200)` returned 135 cells covering 0.000045% of the distribution, and `binomialDistribution(10000, 0.5)` returned 135 cells covering none of it. Cells are now taken through `gammaln`, and a table that cannot be completed returns `undefined` rather than a partial one.
+
+NOTE: this is tagged as a minor change but you should be aware that it does change behavior
+for `binomialDistribution`. For most users this won't be a big deal.
+
+1. Both functions now return `undefined` in cases where they used to return an array of non-finite cells. `binomialDistribution(5, NaN)` returned `[NaN]` and now returns `undefined`. Their TypeScript declarations widen to `number[] | undefined`.
+2. Evaluating cells through logarithms costs a precision where the old product form was exact: `binomialDistribution(2, 0.5)` returns `[0.25000000000000006, 0.5000000000000006, 0.25000000000000006]` rather than `[0.25, 0.5, 0.25]`. This precision loss is small but if you're comparing exact results, it may require updates or rounding.

--- a/.changeset/discrete-pmf-overflow.md
+++ b/.changeset/discrete-pmf-overflow.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `poissonDistribution()` and `binomialDistribution()` returning a truncated table ending in `Infinity` or `NaN`. Both built each cell from a power and a factorial (or a binomial coefficient) that leave floating-point range long before their product does, so the cumulative-probability stopping rule was satisfied by a non-finite sum instead of by the distribution: `poissonDistribution(200)` returned 135 cells covering 0.000045% of the distribution, and `binomialDistribution(10000, 0.5)` returned 135 cells covering none of it. Cells are now taken through `gammaln`, and a table that cannot be completed returns `undefined` rather than a partial one.

--- a/src/binomial_distribution.d.ts
+++ b/src/binomial_distribution.d.ts
@@ -4,6 +4,6 @@
 declare function binomialDistribution(
     trials: number,
     probability: number
-): number[];
+): number[] | undefined;
 
 export default binomialDistribution;

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -7,42 +7,6 @@ import gammaln from "./gammaln.js";
 const maxCells = 1e6;
 
 /**
- * The probability of exactly `x` successes, taken through its logarithm: the
- * binomial coefficient and the two powers each leave floating-point range long
- * before the product they form does, so computing them separately loses cells
- * the distribution needs.
- *
- * @private
- * @param {number} trials number of trials
- * @param {number} probability probability of success in one trial
- * @param {number} x number of successes
- * @returns {number} probability of exactly `x` successes
- */
-function probabilityOfSuccesses(trials, probability, x) {
-    // The logarithms below are undefined at the ends of the probability range,
-    // where the outcome is certain anyway.
-    if (probability === 0) {
-        if (x === 0) {
-            return 1;
-        }
-        return 0;
-    }
-    if (probability === 1) {
-        if (x === trials) {
-            return 1;
-        }
-        return 0;
-    }
-    return Math.exp(
-        gammaln(trials + 1) -
-            gammaln(x + 1) -
-            gammaln(trials - x + 1) +
-            x * Math.log(probability) +
-            (trials - x) * Math.log(1 - probability)
-    );
-}
-
-/**
  * The [Binomial Distribution](http://en.wikipedia.org/wiki/Binomial_distribution) is the discrete probability
  * distribution of the number of successes in a sequence of n independent yes/no experiments, each of which yields
  * success with probability `probability`. Such a success/failure experiment is also called a Bernoulli experiment or
@@ -50,7 +14,7 @@ function probabilityOfSuccesses(trials, probability, x) {
  *
  * @param {number} trials number of trials to simulate
  * @param {number} probability
- * @returns {number[]} output
+ * @returns {number[] | undefined} output
  */
 function binomialDistribution(trials, probability) /*: ?number[] */ {
     // Check that `p` is a valid probability (0 ≤ p ≤ 1),
@@ -72,12 +36,43 @@ function binomialDistribution(trials, probability) /*: ?number[] */ {
     // what we can allocate.
     const lastCell = Math.min(trials, maxCells - 1);
 
+    // These are loop-invariant, so calculate them once up front.
+    const logProbability = Math.log(probability);
+    const log1Probability = Math.log(1 - probability);
+    const gammalnTrials1 = gammaln(trials + 1);
+
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
-        // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function)
-        cells[x] = probabilityOfSuccesses(trials, probability, x);
+        // The probability of exactly `x` successes, taken through its logarithm: the
+        // binomial coefficient and the two powers each leave floating-point range long
+        // before the product they form does, so computing them separately loses cells
+        // the distribution needs.
+        // The logarithms below are undefined at the ends of the probability range,
+        // where the outcome is certain anyway.
+        if (probability === 0) {
+            if (x === 0) {
+                cells[x] = 1;
+            } else {
+                cells[x] = 0;
+            }
+        } else if (probability === 1) {
+            if (x === trials) {
+                cells[x] = 1;
+            } else {
+                cells[x] = 0;
+            }
+        } else {
+            cells[x] = Math.exp(
+                gammalnTrials1 -
+                    gammaln(x + 1) -
+                    gammaln(trials - x + 1) +
+                    x * logProbability +
+                    (trials - x) * log1Probability
+            );
+        }
+
         cumulativeProbability += cells[x];
         x++;
         // when the cumulativeProbability is nearly 1, we've calculated

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -1,4 +1,46 @@
 import epsilon from "./epsilon.js";
+import gammaln from "./gammaln.js";
+
+// A distribution over more trials than this would need a table we cannot
+// allocate. Past that we report a distribution we cannot produce rather than
+// a partial one.
+const maxCells = 1e6;
+
+/**
+ * The probability of exactly `x` successes, taken through its logarithm: the
+ * binomial coefficient and the two powers each leave floating-point range long
+ * before the product they form does, so computing them separately loses cells
+ * the distribution needs.
+ *
+ * @private
+ * @param {number} trials number of trials
+ * @param {number} probability probability of success in one trial
+ * @param {number} x number of successes
+ * @returns {number} probability of exactly `x` successes
+ */
+function probabilityOfSuccesses(trials, probability, x) {
+    // The logarithms below are undefined at the ends of the probability range,
+    // where the outcome is certain anyway.
+    if (probability === 0) {
+        if (x === 0) {
+            return 1;
+        }
+        return 0;
+    }
+    if (probability === 1) {
+        if (x === trials) {
+            return 1;
+        }
+        return 0;
+    }
+    return Math.exp(
+        gammaln(trials + 1) -
+            gammaln(x + 1) -
+            gammaln(trials - x + 1) +
+            x * Math.log(probability) +
+            (trials - x) * Math.log(1 - probability)
+    );
+}
 
 /**
  * The [Binomial Distribution](http://en.wikipedia.org/wiki/Binomial_distribution) is the discrete probability
@@ -26,23 +68,31 @@ function binomialDistribution(trials, probability) /*: ?number[] */ {
     let x = 0;
     let cumulativeProbability = 0;
     const cells = [];
-    let binomialCoefficient = 1;
+    // More successes than trials are impossible, and the table cannot outgrow
+    // what we can allocate.
+    const lastCell = Math.min(trials, maxCells - 1);
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
         // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function)
-        cells[x] =
-            binomialCoefficient *
-            Math.pow(probability, x) *
-            Math.pow(1 - probability, trials - x);
+        cells[x] = probabilityOfSuccesses(trials, probability, x);
         cumulativeProbability += cells[x];
         x++;
-        binomialCoefficient = (binomialCoefficient * (trials - x + 1)) / x;
         // when the cumulativeProbability is nearly 1, we've calculated
         // the useful range of this distribution
-    } while (cumulativeProbability < 1 - epsilon);
+    } while (cumulativeProbability < 1 - epsilon && x <= lastCell);
+
+    // Stopping for any other reason - a probability that is not a number, or
+    // more trials than the table can hold - leaves cells that do not add up to
+    // a distribution, so report that rather than returning them.
+    if (
+        Number.isNaN(cumulativeProbability) ||
+        cumulativeProbability < 1 - epsilon
+    ) {
+        return undefined;
+    }
 
     return cells;
 }

--- a/src/binomial_distribution.js
+++ b/src/binomial_distribution.js
@@ -1,16 +1,16 @@
 import epsilon from "./epsilon.js";
 import gammaln from "./gammaln.js";
-
-// A distribution over more trials than this would need a table we cannot
-// allocate. Past that we report a distribution we cannot produce rather than
-// a partial one.
-const maxCells = 1e6;
+import maxDistributionCells from "./max_distribution_cells.js";
 
 /**
  * The [Binomial Distribution](http://en.wikipedia.org/wiki/Binomial_distribution) is the discrete probability
  * distribution of the number of successes in a sequence of n independent yes/no experiments, each of which yields
  * success with probability `probability`. Such a success/failure experiment is also called a Bernoulli experiment or
  * Bernoulli trial; when trials = 1, the Binomial Distribution is a Bernoulli Distribution.
+ *
+ * Returns `undefined` when the distribution cannot be calculated: either
+ * argument is outside its domain or is not a number, or when `trials` is large
+ * enough that the table would run past a million cells.
  *
  * @param {number} trials number of trials to simulate
  * @param {number} probability
@@ -23,59 +23,57 @@ function binomialDistribution(trials, probability) /*: ?number[] */ {
         return undefined;
     }
 
-    // We initialize `x`, the random variable, and `accumulator`, an accumulator
-    // for the cumulative distribution function to 0. `distribution_functions`
-    // is the object we'll return with the `probability_of_x` and the
-    // `cumulativeProbability_of_x`, as well as the calculated mean &
-    // variance. We iterate until the `cumulativeProbability_of_x` is
-    // within `epsilon` of 1.0.
+    // More successes than trials are impossible, and the table cannot outgrow
+    // what we can allocate.
+    const lastCell = Math.min(trials, maxDistributionCells - 1);
+
+    // The logarithms below are undefined at the ends of the probability range,
+    // where the outcome is certain anyway.
+    if (probability === 0) {
+        return [1];
+    }
+    if (probability === 1) {
+        if (trials > lastCell) {
+            return undefined;
+        }
+        const certain = new Array(trials + 1).fill(0);
+        certain[trials] = 1;
+        return certain;
+    }
+
+    // `x` is the random variable: the number of successes. We iterate until
+    // the cumulative probability is within `epsilon` of 1.0, at which point we
+    // have the useful range of the distribution.
     let x = 0;
     let cumulativeProbability = 0;
     const cells = [];
-    // More successes than trials are impossible, and the table cannot outgrow
-    // what we can allocate.
-    const lastCell = Math.min(trials, maxCells - 1);
 
-    // These are loop-invariant, so calculate them once up front.
+    // The terms of the mass function below that do not vary with `x`
+    const logTrialsFactorial = gammaln(trials + 1);
     const logProbability = Math.log(probability);
-    const log1Probability = Math.log(1 - probability);
-    const gammalnTrials1 = gammaln(trials + 1);
+    // `log1p` rather than `Math.log(1 - probability)`, which cancels away the
+    // low digits of the complement as `probability` approaches 1.
+    const log1mProbability = Math.log1p(-probability);
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
-        // The probability of exactly `x` successes, taken through its logarithm: the
-        // binomial coefficient and the two powers each leave floating-point range long
-        // before the product they form does, so computing them separately loses cells
-        // the distribution needs.
-        // The logarithms below are undefined at the ends of the probability range,
-        // where the outcome is certain anyway.
-        if (probability === 0) {
-            if (x === 0) {
-                cells[x] = 1;
-            } else {
-                cells[x] = 0;
-            }
-        } else if (probability === 1) {
-            if (x === trials) {
-                cells[x] = 1;
-            } else {
-                cells[x] = 0;
-            }
-        } else {
-            cells[x] = Math.exp(
-                gammalnTrials1 -
-                    gammaln(x + 1) -
-                    gammaln(trials - x + 1) +
-                    x * logProbability +
-                    (trials - x) * log1Probability
-            );
-        }
-
+        // A [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function),
+        // taken through its logarithm: the binomial coefficient and the two
+        // powers each leave floating-point range long before the product they
+        // form does, so computing them separately loses cells the distribution
+        // needs.
+        cells[x] = Math.exp(
+            logTrialsFactorial -
+                gammaln(x + 1) -
+                gammaln(trials - x + 1) +
+                x * logProbability +
+                (trials - x) * log1mProbability
+        );
         cumulativeProbability += cells[x];
         x++;
-        // when the cumulativeProbability is nearly 1, we've calculated
+        // When the `cumulativeProbability` is nearly 1, we've calculated
         // the useful range of this distribution
     } while (cumulativeProbability < 1 - epsilon && x <= lastCell);
 

--- a/src/max_distribution_cells.js
+++ b/src/max_distribution_cells.js
@@ -1,0 +1,9 @@
+/**
+ * Discrete distributions are tabulated cell by cell, and the Poisson
+ * distribution has no upper bound at all, so their tables need a length we can
+ * still allocate. Past this, `binomialDistribution` and `poissonDistribution`
+ * report a distribution they cannot produce rather than a partial one.
+ */
+const maxDistributionCells = 1e6;
+
+export default maxDistributionCells;

--- a/src/poisson_distribution.d.ts
+++ b/src/poisson_distribution.d.ts
@@ -1,6 +1,6 @@
 /**
  * https://simple-statistics.github.io/docs/#poissondistribution
  */
-declare function poissonDistribution(lambda: number): number[];
+declare function poissonDistribution(lambda: number): number[] | undefined;
 
 export default poissonDistribution;

--- a/src/poisson_distribution.js
+++ b/src/poisson_distribution.js
@@ -1,10 +1,6 @@
 import epsilon from "./epsilon.js";
 import gammaln from "./gammaln.js";
-
-// The Poisson distribution has no upper bound, so cap the table at a length we
-// can still allocate. Past that we report a distribution we cannot produce
-// rather than a partial one.
-const maxCells = 1e6;
+import maxDistributionCells from "./max_distribution_cells.js";
 
 /**
  * The [Poisson Distribution](http://en.wikipedia.org/wiki/Poisson_distribution)
@@ -16,8 +12,12 @@ const maxCells = 1e6;
  * The Poisson Distribution is characterized by the strictly positive
  * mean arrival or occurrence rate, `λ`.
  *
+ * Returns `undefined` when the distribution cannot be calculated: when `lambda`
+ * is not a strictly positive number, or when it is large enough that the table
+ * would run past a million cells.
+ *
  * @param {number} lambda location poisson distribution
- * @returns {number[]} values of poisson distribution at that point
+ * @returns {number[] | undefined} values of poisson distribution at that point
  */
 function poissonDistribution(lambda) /*: ?number[] */ {
     // Check that lambda is strictly positive
@@ -25,13 +25,22 @@ function poissonDistribution(lambda) /*: ?number[] */ {
         return undefined;
     }
 
-    // our current place in the distribution
+    // The distribution peaks at `lambda`, so past the length of the table
+    // there is nothing to tabulate and no reason to start.
+    if (lambda >= maxDistributionCells) {
+        return undefined;
+    }
+
+    // Our current place in the distribution
     let x = 0;
-    // and we keep track of the current cumulative probability, in
+    // And we keep track of the current cumulative probability, in
     // order to know when to stop calculating chances.
     let cumulativeProbability = 0;
-    // the calculated cells to be returned
+    // The calculated cells to be returned
     const cells = [];
+
+    // The only term of the mass function below that does not vary with `x`
+    const logLambda = Math.log(lambda);
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
@@ -41,12 +50,12 @@ function poissonDistribution(lambda) /*: ?number[] */ {
         // taken through its logarithm: `lambda` raised to `x` and the factorial
         // of `x` each leave floating-point range long before their ratio does,
         // so computing them separately loses cells the distribution needs.
-        cells[x] = Math.exp(x * Math.log(lambda) - lambda - gammaln(x + 1));
+        cells[x] = Math.exp(x * logLambda - lambda - gammaln(x + 1));
         cumulativeProbability += cells[x];
         x++;
-        // when the cumulativeProbability is nearly 1, we've calculated
+        // When the `cumulativeProbability` is nearly 1, we've calculated
         // the useful range of this distribution
-    } while (cumulativeProbability < 1 - epsilon && x < maxCells);
+    } while (cumulativeProbability < 1 - epsilon && x < maxDistributionCells);
 
     // Stopping for any other reason - a lambda that is not a number, or a
     // distribution too wide for the table - leaves cells that do not add up to

--- a/src/poisson_distribution.js
+++ b/src/poisson_distribution.js
@@ -1,4 +1,10 @@
 import epsilon from "./epsilon.js";
+import gammaln from "./gammaln.js";
+
+// The Poisson distribution has no upper bound, so cap the table at a length we
+// can still allocate. Past that we report a distribution we cannot produce
+// rather than a partial one.
+const maxCells = 1e6;
 
 /**
  * The [Poisson Distribution](http://en.wikipedia.org/wiki/Poisson_distribution)
@@ -26,20 +32,31 @@ function poissonDistribution(lambda) /*: ?number[] */ {
     let cumulativeProbability = 0;
     // the calculated cells to be returned
     const cells = [];
-    let factorialX = 1;
 
     // This algorithm iterates through each potential outcome,
     // until the `cumulativeProbability` is very close to 1, at
     // which point we've defined the vast majority of outcomes
     do {
-        // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function)
-        cells[x] = (Math.exp(-lambda) * Math.pow(lambda, x)) / factorialX;
+        // a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function),
+        // taken through its logarithm: `lambda` raised to `x` and the factorial
+        // of `x` each leave floating-point range long before their ratio does,
+        // so computing them separately loses cells the distribution needs.
+        cells[x] = Math.exp(x * Math.log(lambda) - lambda - gammaln(x + 1));
         cumulativeProbability += cells[x];
         x++;
-        factorialX *= x;
         // when the cumulativeProbability is nearly 1, we've calculated
         // the useful range of this distribution
-    } while (cumulativeProbability < 1 - epsilon);
+    } while (cumulativeProbability < 1 - epsilon && x < maxCells);
+
+    // Stopping for any other reason - a lambda that is not a number, or a
+    // distribution too wide for the table - leaves cells that do not add up to
+    // a distribution, so report that rather than returning them.
+    if (
+        Number.isNaN(cumulativeProbability) ||
+        cumulativeProbability < 1 - epsilon
+    ) {
+        return undefined;
+    }
 
     return cells;
 }

--- a/test/binomial_distribution.test.js
+++ b/test/binomial_distribution.test.js
@@ -48,6 +48,84 @@ describe("binomialDistribution", function () {
         );
     });
 
+    // The binomial coefficient and the two powers each leave floating-point
+    // range well before the distribution peaks, which used to end the table
+    // early on a cell of Infinity or NaN: binomialDistribution(1021, 0.5)
+    // returned 497 cells worth 19% of the distribution, and
+    // binomialDistribution(10000, 0.5) returned 135 cells worth none of it.
+    it("describes the whole distribution for a large number of trials", function () {
+        const cases = [
+            [1020, 0.5],
+            [1021, 0.5],
+            [2000, 0.5],
+            [10000, 0.5],
+            [10000, 0.999],
+            [100000, 0.001]
+        ];
+        for (const parameters of cases) {
+            const label = parameters[0] + ", " + parameters[1];
+            const cells = ss.binomialDistribution(parameters[0], parameters[1]);
+            assert.ok(
+                cells.every(Number.isFinite),
+                label + " has a cell that is not a number"
+            );
+            assert.ok(
+                ss.sum(cells) >= 1 - ss.epsilon,
+                label + " stops short of the distribution"
+            );
+            assert.ok(
+                cells.length <= parameters[0] + 1,
+                label + " runs past the last possible outcome"
+            );
+        }
+    });
+
+    it("peaks at the mean for a large number of trials", function () {
+        const cells = ss.binomialDistribution(10000, 0.5);
+        assert.equal(cells.indexOf(ss.max(cells)), 5000);
+    });
+
+    // Reference cells evaluated at 50 significant digits with mpmath and
+    // cross-checked against scipy.stats.binom.pmf.
+    it("matches reference cells for a large number of trials", function () {
+        const references = [
+            [1021, 0.5, 510, 0.024952173249668672],
+            [2000, 0.5, 900, 8.0046118774649461e-7],
+            [2000, 0.5, 1000, 0.01783901114585432],
+            [10000, 0.5, 5000, 0.0079786461393821541],
+            [100000, 0.001, 50, 1.2082375507591476e-8],
+            [100000, 0.001, 100, 0.039880942234625599]
+        ];
+        for (const reference of references) {
+            const cells = ss.binomialDistribution(reference[0], reference[1]);
+            assert.ok(
+                ss.approxEqual(cells[reference[2]], reference[3], 1e-8),
+                reference[0] +
+                    ", " +
+                    reference[1] +
+                    " at " +
+                    reference[2] +
+                    ": " +
+                    cells[reference[2]] +
+                    " != " +
+                    reference[3]
+            );
+        }
+    });
+
+    it("keeps the certain outcomes at the ends of the probability range", function () {
+        assert.deepEqual(ss.binomialDistribution(10, 0), [1]);
+        const allSuccesses = ss.binomialDistribution(10, 1);
+        assert.equal(allSuccesses.length, 11);
+        assert.equal(allSuccesses[10], 1);
+        assert.equal(ss.sum(allSuccesses), 1);
+    });
+
+    it("can return undefined when the distribution cannot be tabulated", function () {
+        assert.equal(undefined, ss.binomialDistribution(5, Number.NaN));
+        assert.equal(undefined, ss.binomialDistribution(1e9, 0.5));
+    });
+
     it("can return null when p or n are not valid parameters", function () {
         assert.equal(
             ss.binomialDistribution(0, 0.5),

--- a/test/binomial_distribution.test.js
+++ b/test/binomial_distribution.test.js
@@ -124,6 +124,10 @@ describe("binomialDistribution", function () {
     it("can return undefined when the distribution cannot be tabulated", function () {
         assert.equal(undefined, ss.binomialDistribution(5, Number.NaN));
         assert.equal(undefined, ss.binomialDistribution(1e9, 0.5));
+        // The table holds a million cells, so the last distribution that can
+        // reach its own final outcome is the one over 999999 trials.
+        assert.equal(ss.binomialDistribution(999999, 1).length, 1000000);
+        assert.equal(undefined, ss.binomialDistribution(1000000, 1));
     });
 
     it("can return null when p or n are not valid parameters", function () {

--- a/test/poisson_distribution.test.js
+++ b/test/poisson_distribution.test.js
@@ -29,4 +29,68 @@ describe("poissonDistribution", function () {
         assert.equal(undefined, ss.poissonDistribution(0));
         assert.equal(undefined, ss.poissonDistribution(-10));
     });
+
+    // lambda ^ x and x! both leave floating-point range well before the
+    // distribution peaks, which used to end the table early on a cell of
+    // Infinity or NaN: lambda = 200 returned 135 cells worth 0.000045% of the
+    // distribution, and lambda = 1000 returned 104 cells worth none of it.
+    it("describes the whole distribution for a large lambda", function () {
+        for (const lambda of [1, 50, 110, 111, 150, 200, 745, 746, 1000]) {
+            const cells = ss.poissonDistribution(lambda);
+            assert.ok(
+                cells.every(Number.isFinite),
+                "lambda " + lambda + " has a cell that is not a number"
+            );
+            assert.ok(
+                ss.sum(cells) >= 1 - ss.epsilon,
+                "lambda " + lambda + " stops short of the distribution"
+            );
+            assert.ok(
+                cells.length > lambda,
+                "lambda " + lambda + " stops before its own mean"
+            );
+        }
+    });
+
+    it("peaks at the mean for a large lambda", function () {
+        const cells = ss.poissonDistribution(200);
+        assert.equal(cells.indexOf(ss.max(cells)), 199);
+    });
+
+    // Reference cells evaluated at 50 significant digits with mpmath and
+    // cross-checked against scipy.stats.poisson.pmf.
+    it("matches reference cells for a large lambda", function () {
+        const references = [
+            [111, 111, 0.03783750840195968],
+            [150, 150, 0.032555409456836548],
+            [200, 134, 1.5122660970724418e-7],
+            [200, 199, 0.028197727685920822],
+            [746, 746, 0.014604683118189346],
+            [1000, 900, 7.5169543521259519e-5],
+            [1000, 1000, 0.012614611348721499]
+        ];
+        for (const reference of references) {
+            const cells = ss.poissonDistribution(reference[0]);
+            assert.ok(
+                ss.approxEqual(cells[reference[1]], reference[2], 1e-9),
+                "lambda " +
+                    reference[0] +
+                    " at " +
+                    reference[1] +
+                    ": " +
+                    cells[reference[1]] +
+                    " != " +
+                    reference[2]
+            );
+        }
+    });
+
+    it("can return undefined when the distribution cannot be tabulated", function () {
+        assert.equal(undefined, ss.poissonDistribution(Number.NaN));
+        assert.equal(
+            undefined,
+            ss.poissonDistribution(Number.POSITIVE_INFINITY)
+        );
+        assert.equal(undefined, ss.poissonDistribution(1e9));
+    });
 });

--- a/test/poisson_distribution.test.js
+++ b/test/poisson_distribution.test.js
@@ -6,7 +6,7 @@ function rnd(n) {
     return Number.parseFloat(n.toFixed(4));
 }
 
-// expected cumulative probabilities taken from Appendix 1, Table I of William W. Hines & Douglas C.
+// Expected cumulative probabilities taken from Appendix 1, Table I of William W. Hines & Douglas C.
 // Montgomery, "Probability and Statistics in Engineering and Management Science", Wiley (1980).
 describe("poissonDistribution", function () {
     it("can return generate probability and cumulative probability distributions for lambda = 3.0", function () {
@@ -52,9 +52,14 @@ describe("poissonDistribution", function () {
         }
     });
 
+    // lambda - 1 and lambda are both modes of an integer-valued Poisson, and
+    // they come out of the mass function equal to the last bit, so which one
+    // indexOf reports rests on nothing more than the rounding of Math.exp and
+    // Math.log - which the language does not pin down. Accept either.
     it("peaks at the mean for a large lambda", function () {
         const cells = ss.poissonDistribution(200);
-        assert.equal(cells.indexOf(ss.max(cells)), 199);
+        const peak = cells.indexOf(ss.max(cells));
+        assert.ok(peak === 199 || peak === 200, "peaks at " + peak);
     });
 
     // Reference cells evaluated at 50 significant digits with mpmath and


### PR DESCRIPTION
Tweak PR of https://github.com/simple-statistics/simple-statistics/pull/811

- Makes the changeset more descriptive about potentially breaking behavior
- Improves performance slightly
- Adjusts the type signatures to be honest about sometimes returning `undefined`

---

poissonDistribution and binomialDistribution built each cell from factors
that leave floating-point range long before their product does: lambda to
the power of x over x factorial, and a binomial coefficient times two
powers. Once one of those factors reached Infinity the cell became
Infinity or NaN, the cumulative-probability stopping rule was satisfied by
a non-finite sum rather than by the distribution, and the function returned
a table that stopped short of its own mean and ended on that cell.

poissonDistribution(200) returned 135 cells covering 4.5e-7 of the
distribution and ending in Infinity, against a mode at 200;
binomialDistribution(10000, 0.5) returned 135 cells that were all zero
except a final NaN. The threshold is lambda >= 111 and, at p = 0.5,
trials >= 1021.

Both functions now take each cell through gammaln, which the library
already ships for exactly this reason, and check the cumulative
probability after the loop so that a table which could not be completed
is reported as undefined instead of returned in part. The loops are
bounded, so a lambda or trial count too large to tabulate returns
undefined rather than exhausting memory.

Cells that used to be exact within a few ulps are now accurate to about
1e-13 at 1000 trials and 1e-11 at 10000, the cost of evaluating each cell
independently through logarithms; that is far inside the epsilon the
functions use as their own stopping rule.