### PR TITLE
fix(perceptron): declare that predict and train can return null

### DIFF
--- a/.changeset/perceptron-null-return-types.md
+++ b/.changeset/perceptron-null-return-types.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Declare that `PerceptronModel#predict` and `PerceptronModel#train` can return `null`. `predict` returns `null` when the feature array's length differs from what the model was trained on, and `train` returns `null` when the label is not 0 or 1 — both since their introduction — but the type declarations promised plain `number` and `PerceptronModel`, so TypeScript consumers under `strictNullChecks` got no warning before dereferencing the result. Runtime behavior is unchanged; only the declarations and docstrings now state the `null` cases.

--- a/src/perceptron.d.ts
+++ b/src/perceptron.d.ts
@@ -4,8 +4,8 @@
 declare class PerceptronModel {
     public weights: readonly number[];
     public bias: number;
-    predict(features: readonly number[]): number;
-    train(features: readonly number[], label: number): PerceptronModel;
+    predict(features: readonly number[]): number | null;
+    train(features: readonly number[], label: number): PerceptronModel | null;
 }
 
 export default PerceptronModel;

--- a/src/perceptron.js
+++ b/src/perceptron.js
@@ -35,7 +35,8 @@ class PerceptronModel {
      * to predict whether an example is labeled 0 or 1.
      *
      * @param {Array<number>} features an array of features as numbers
-     * @returns {number} 1 if the score is over 0, otherwise 0
+     * @returns {number|null} 1 if the score is over 0, otherwise 0; null if
+     * the model has not been trained on feature arrays of this length
      */
     predict(features) {
         // Only predict if previously trained
@@ -66,7 +67,7 @@ class PerceptronModel {
      *
      * @param {Array<number>} features an array of features as numbers
      * @param {number} label either 0 or 1
-     * @returns {PerceptronModel} this
+     * @returns {PerceptronModel|null} this, or null if the label is not 0 or 1
      */
     train(features, label) {
         // Require that only labels of 0 or 1 are considered.

--- a/test/types.ts
+++ b/test/types.ts
@@ -74,6 +74,8 @@ p.predict([0, 0]); // 0
 p.predict([0, 1]); // 0
 p.predict([1, 0]); // 0
 p.predict([1, 1]); // 1
+p.predict([]); // null: feature length differs from the trained length
+p.train([1, 2], 0.5); // null: label is not 0 or 1
 ss.product([1, 2, 3, 4]); // => 24
 ss.quantileSorted([3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20], 0.5); // => 9
 ss.quantile([3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20], 0.5); // => 9


### PR DESCRIPTION
Closes #715.

## Summary

`PerceptronModel#predict` and `#train` have returned `null` since their introduction — `predict` when the feature array's length differs from what the model was trained on, `train` when the label is not 0 or 1 — but `src/perceptron.d.ts` declared plain `number` and `PerceptronModel`. A `strictNullChecks` consumer can write `model.predict(x).toFixed(1)`, type-check clean, and crash at runtime.

This takes option 1 from the issue (declare the `null`) rather than option 2 (throw): the unit tests pin the current behaviour — `test/perceptron.test.js` asserts `p.predict([])` and `p.train([1, 2, 3], 0.5)` both return `null` — so switching to throwing is a breaking change that seems like a maintainer call. Runtime behaviour is deliberately unchanged.

## Changes

- `src/perceptron.d.ts` — `predict` → `number | null`, `train` → `PerceptronModel | null`
- `src/perceptron.js` — the two `@returns` docstrings now state when `null` is returned
- `test/types.ts` — two consumer lines documenting the `null` cases, mirroring the unit tests
- a patch changeset

## Testing

- `pnpm test` on this branch: **294 tests, 294 pass, 0 fail** (the script also runs `tsc --skipLibCheck --noEmit`, biome, and `documentation lint src` — all clean).
- Discriminating check with the repo's own TypeScript against a minimal `--strict` consumer that dereferences both results:
  - old declarations: compiles **clean** (exit 0) — the hazard, since the same code throws `TypeError: Cannot read properties of null (reading 'toFixed')` at runtime (verified with node against `src/perceptron.js`);
  - these declarations: `TS18047: 'label' is possibly 'null'` and `TS2531: Object is possibly 'null'` (exit 1), as it should.
- Note the repo's own `tsconfig.json` doesn't enable `strictNullChecks`, so `test/types.ts` compiles both with and without this fix — the added lines there document the contract; the enforcement lands in consumers' strict projects.
