### PR TITLE
docs(permutation-test): correct alternative values to 'two_side'

### DIFF
--- a/.changeset/permutation-test-two-side-docs.md
+++ b/.changeset/permutation-test-two-side-docs.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Correct `permutationTest`'s JSDoc to name the `alternative` value the implementation accepts. The docs described the two-sided test as `two_tail` and `'two_sided' (default)`, but passing either throws `` `alternative` must be either 'two_side', 'greater', or 'less'. `` — only `'two_side'` is accepted. Documentation-only change; runtime behavior is untouched.

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -13,7 +13,7 @@ import shuffleInPlace from "./shuffle_in_place.js";
  *
  * @param {Array<number>} sampleX first dataset (e.g. treatment data)
  * @param {Array<number>} sampleY second dataset (e.g. control data)
- * @param {string} alternative alternative hypothesis, either 'two_side' (default), 'greater', or 'less'
+ * @param {'two_side'|'greater'|'less'} [alternative='two_side'] alternative hypothesis
  * @param {number} k number of values in permutation distribution.
  * @param {Function} [randomSource=Math.random] an optional entropy source
  * @returns {number} p-value The probability of observing the difference between groups (as or more extreme than what we did), assuming the null hypothesis.

--- a/src/permutation_test.js
+++ b/src/permutation_test.js
@@ -6,14 +6,14 @@ import shuffleInPlace from "./shuffle_in_place.js";
  * to determine if two data sets are *significantly* different from each other, using
  * the difference of means between the groups as the test statistic.
  * The function allows for the following hypotheses:
- * - two_tail = Null hypothesis: the two distributions are equal.
+ * - two_side = Null hypothesis: the two distributions are equal.
  * - greater = Null hypothesis: observations from sampleX tend to be smaller than those from sampleY.
  * - less = Null hypothesis: observations from sampleX tend to be greater than those from sampleY.
  * [Learn more about one-tail vs two-tail tests.](https://en.wikipedia.org/wiki/One-_and_two-tailed_tests)
  *
  * @param {Array<number>} sampleX first dataset (e.g. treatment data)
  * @param {Array<number>} sampleY second dataset (e.g. control data)
- * @param {string} alternative alternative hypothesis, either 'two_sided' (default), 'greater', or 'less'
+ * @param {string} alternative alternative hypothesis, either 'two_side' (default), 'greater', or 'less'
  * @param {number} k number of values in permutation distribution.
  * @param {Function} [randomSource=Math.random] an optional entropy source
  * @returns {number} p-value The probability of observing the difference between groups (as or more extreme than what we did), assuming the null hypothesis.


### PR DESCRIPTION
Related: https://github.com/simple-statistics/simple-statistics/issues/469

## Summary

Calling `permutationTest` with either documented `alternative` value throws. The JSDoc names the two-sided option `two_tail` in the hypothesis list and `'two_sided' (default)` in the parameter line, but the implementation accepts only `'two_side'`:

```js
permutationTest([1, 2, 3], [4, 5, 6], "two_sided")
// Error: `alternative` must be either 'two_side', 'greater', or 'less'.
permutationTest([1, 2, 3], [4, 5, 6], "two_tail")
// Error: `alternative` must be either 'two_side', 'greater', or 'less'.
```

Both documented names are corrected to `two_side`, the value the code branches on.

## What is deliberately unchanged

The accepted string itself. `'two_side'` has been the public API since the function landed, so renaming the code to match the docs would break existing callers to gain a nicer spelling. The p-value math is also untouched — the numerical question in #469 was settled in the thread (the library's two-sided value is correct; the discrepancy belonged to the Python package).

## Testing

`pnpm test` on the branch, re-run 2026-08-15: tsc, biome, documentation lint, and the node:test suite all pass — **294/294 tests, 0 failures**. The branch is based on `8449cf5`; it merges cleanly into current `main` (`0c33928`), verified with `git merge-tree --write-tree`.

Documentation-only, so no failing-before test is possible in this repo; the fail-before evidence is the repro above, run against code identical to `main` at that base.

---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*
