### PR TITLE
feat(probability): add normalDistribution (NORM.DIST equivalent)

### DIFF
--- a/.changeset/normal-distribution.md
+++ b/.changeset/normal-distribution.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+Add `normalDistribution(x, mean, standardDeviation, cumulative)`, the equivalent of spreadsheet `NORM.DIST`. With `cumulative` false (the default) it returns the normal probability density, which the library previously had no function for; with `cumulative` true it returns the cumulative probability via `errorFunction`, avoiding the two-decimal z rounding and four-decimal table values that bound `cumulativeStdNormalProbability`'s precision.

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,7 @@ export {
     default as kde
 } from "./src/kernel_density_estimation";
 export { default as logit } from "./src/logit";
+export { default as normalDistribution } from "./src/normal_distribution";
 export { default as numericSort } from "./src/numeric_sort";
 export {
     default as PerceptronModel,

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ export {
     default as kde
 } from "./src/kernel_density_estimation.js";
 export { default as logit } from "./src/logit.js";
+export { default as normalDistribution } from "./src/normal_distribution.js";
 export { default as numericSort } from "./src/numeric_sort.js";
 export {
     default as PerceptronModel,

--- a/src/normal_distribution.d.ts
+++ b/src/normal_distribution.d.ts
@@ -1,0 +1,11 @@
+/**
+ * https://simple-statistics.github.io/docs/#normaldistribution
+ */
+declare function normalDistribution(
+    x: number,
+    mean: number,
+    standardDeviation: number,
+    cumulative?: boolean
+): number;
+
+export default normalDistribution;

--- a/src/normal_distribution.js
+++ b/src/normal_distribution.js
@@ -1,0 +1,55 @@
+import errorFunction from "./error_function.js";
+
+/**
+ * **[Normal distribution](https://en.wikipedia.org/wiki/Normal_distribution)**
+ *
+ * Returns either the probability density or the cumulative probability of a
+ * normal distribution with the given mean and standard deviation, evaluated
+ * at x. It is the equivalent of the NORM.DIST function found in spreadsheet
+ * software.
+ *
+ * The cumulative form is computed with `errorFunction`, so it is more precise
+ * than converting x to a z-score and looking it up in the four-decimal
+ * `standardNormalTable` used by `cumulativeStdNormalProbability`.
+ *
+ * @param {number} x the value for which you want the distribution
+ * @param {number} mean the mean of the distribution
+ * @param {number} standardDeviation the standard deviation of the distribution
+ * @param {boolean} [cumulative=false] if true, return the cumulative
+ * distribution function; if false, return the probability density function
+ * @returns {number} the probability density at x, or the probability of a
+ * value at most x
+ * @throws {Error} if standardDeviation is not greater than zero
+ * @throws {Error} if cumulative is neither true nor false
+ * @example
+ * normalDistribution(42, 40, 1.5, true).toFixed(4); // => '0.9088'
+ * normalDistribution(42, 40, 1.5, false).toFixed(4); // => '0.1093'
+ */
+function normalDistribution(x, mean, standardDeviation, cumulative) {
+    // Set default arguments
+    if (cumulative === undefined) {
+        cumulative = false;
+    }
+    if (cumulative !== true && cumulative !== false) {
+        throw new Error(
+            "normalDistribution requires cumulative to be true or false"
+        );
+    }
+    if (standardDeviation <= 0) {
+        throw new Error(
+            "normalDistribution requires a standard deviation greater than zero"
+        );
+    }
+
+    const standardizedX = (x - mean) / standardDeviation;
+
+    if (cumulative === true) {
+        return 0.5 * (1 + errorFunction(standardizedX / Math.SQRT2));
+    }
+    return (
+        Math.exp(-0.5 * standardizedX * standardizedX) /
+        (standardDeviation * Math.sqrt(2 * Math.PI))
+    );
+}
+
+export default normalDistribution;

--- a/src/normal_distribution.js
+++ b/src/normal_distribution.js
@@ -20,21 +20,11 @@ import errorFunction from "./error_function.js";
  * @returns {number} the probability density at x, or the probability of a
  * value at most x
  * @throws {Error} if standardDeviation is not greater than zero
- * @throws {Error} if cumulative is neither true nor false
  * @example
  * normalDistribution(42, 40, 1.5, true).toFixed(4); // => '0.9088'
  * normalDistribution(42, 40, 1.5, false).toFixed(4); // => '0.1093'
  */
-function normalDistribution(x, mean, standardDeviation, cumulative) {
-    // Set default arguments
-    if (cumulative === undefined) {
-        cumulative = false;
-    }
-    if (cumulative !== true && cumulative !== false) {
-        throw new Error(
-            "normalDistribution requires cumulative to be true or false"
-        );
-    }
+function normalDistribution(x, mean, standardDeviation, cumulative = false) {
     if (standardDeviation <= 0) {
         throw new Error(
             "normalDistribution requires a standard deviation greater than zero"
@@ -43,7 +33,7 @@ function normalDistribution(x, mean, standardDeviation, cumulative) {
 
     const standardizedX = (x - mean) / standardDeviation;
 
-    if (cumulative === true) {
+    if (cumulative) {
         return 0.5 * (1 + errorFunction(standardizedX / Math.SQRT2));
     }
     return (

--- a/test/normal_distribution.test.js
+++ b/test/normal_distribution.test.js
@@ -137,11 +137,4 @@ describe("normalDistribution", function () {
         assert.throws(() => ss.normalDistribution(42, 40, 0, true));
         assert.throws(() => ss.normalDistribution(42, 40, -1.5, true));
     });
-
-    it("throws when cumulative is not a boolean", function () {
-        // Spreadsheet software coerces NORM.DIST's fourth argument, so a
-        // ported call site could pass 1 and silently expect the cumulative
-        // form; throwing makes that mistake visible.
-        assert.throws(() => ss.normalDistribution(42, 40, 1.5, 1));
-    });
 });

--- a/test/normal_distribution.test.js
+++ b/test/normal_distribution.test.js
@@ -92,8 +92,8 @@ describe("normalDistribution", function () {
     });
 
     it("P(X <= mean) is one half within the error function's precision", function () {
-        // errorFunction approximates erf(0) as about 3.1e-8 rather than
-        // zero, so the cumulative probability at the mean is not exactly
+        // errorFunction approximates erf(0) as about -3.0e-8 rather than
+        // zero, so the cumulative probability at the mean falls just below
         // one half. The approximation's absolute error stays below 1.5e-7.
         assert.ok(
             Math.abs(ss.normalDistribution(40, 40, 1.5, true) - 0.5) < 1e-7

--- a/test/normal_distribution.test.js
+++ b/test/normal_distribution.test.js
@@ -60,3 +60,88 @@ describe("natural distribution and z-score", function () {
         assert.equal(+(prob88 - prob78).toPrecision(5), 0.6006);
     });
 });
+
+describe("normalDistribution", function () {
+    it("NORM.DIST(42, 40, 1.5, TRUE) is 0.9087888", function () {
+        // Cumulative example documented at
+        // https://support.microsoft.com/en-us/office/norm-dist-function-edb1cc14-a21c-4e53-839d-8082074c9f8d
+        // Reference value 0.9087887802741321 from erf in the C standard library.
+        assert.ok(
+            Math.abs(
+                ss.normalDistribution(42, 40, 1.5, true) - 0.9087887802741321
+            ) < 1e-7
+        );
+    });
+
+    it("NORM.DIST(42, 40, 1.5, FALSE) is 0.10934", function () {
+        // Density example documented at
+        // https://support.microsoft.com/en-us/office/norm-dist-function-edb1cc14-a21c-4e53-839d-8082074c9f8d
+        assert.ok(
+            Math.abs(
+                ss.normalDistribution(42, 40, 1.5, false) - 0.10934004978399575
+            ) < 1e-12
+        );
+    });
+
+    it("returns the density when cumulative is omitted", function () {
+        // The standard normal density at zero is 1 / sqrt(2 * pi)
+        assert.ok(
+            Math.abs(ss.normalDistribution(0, 0, 1) - 0.3989422804014327) <
+                1e-12
+        );
+    });
+
+    it("P(X <= mean) is one half within the error function's precision", function () {
+        // errorFunction approximates erf(0) as about 3.1e-8 rather than
+        // zero, so the cumulative probability at the mean is not exactly
+        // one half. The approximation's absolute error stays below 1.5e-7.
+        assert.ok(
+            Math.abs(ss.normalDistribution(40, 40, 1.5, true) - 0.5) < 1e-7
+        );
+    });
+
+    it("P(X <= 82) when X ~ N (80, 25) is 0.6554", function () {
+        // The professor example from the cumulativeStdNormalProbability
+        // tests above, without the intermediate z-score.
+        assert.equal(
+            +ss.normalDistribution(82, 80, 5, true).toPrecision(4),
+            0.6554
+        );
+    });
+
+    it("cumulative probabilities are symmetric about the mean", function () {
+        // Start above zero: at x = 0 the check reduces to the previous
+        // test, and the two sides share one computed error function value,
+        // so the symmetry itself holds to floating-point rounding.
+        for (let x = 0.25; x <= 8; x += 0.25) {
+            const above = ss.normalDistribution(4 + x, 4, 2, true);
+            const below = ss.normalDistribution(4 - x, 4, 2, true);
+            assert.ok(Math.abs(above + below - 1) < 1e-12);
+        }
+    });
+
+    it("agrees with the standard normal table", function () {
+        // The table has four decimal places, so its round-trip error is
+        // bounded by 5e-5; allow 1e-3 for the sweep.
+        for (let z = -4; z <= 4; z += 0.25) {
+            assert.ok(
+                Math.abs(
+                    ss.normalDistribution(z, 0, 1, true) -
+                        ss.cumulativeStdNormalProbability(z)
+                ) < 1e-3
+            );
+        }
+    });
+
+    it("throws when the standard deviation is not greater than zero", function () {
+        assert.throws(() => ss.normalDistribution(42, 40, 0, true));
+        assert.throws(() => ss.normalDistribution(42, 40, -1.5, true));
+    });
+
+    it("throws when cumulative is not a boolean", function () {
+        // Spreadsheet software coerces NORM.DIST's fourth argument, so a
+        // ported call site could pass 1 and silently expect the cumulative
+        // form; throwing makes that mistake visible.
+        assert.throws(() => ss.normalDistribution(42, 40, 1.5, 1));
+    });
+});


### PR DESCRIPTION
Closes https://github.com/simple-statistics/simple-statistics/issues/544

## Summary

The library has no normal probability density function, and the cumulative route most users find first (`cumulativeStdNormalProbability`) is a four-decimal table lookup with z rounded to the nearest 0.01 — off by up to 2.0e-3 against numerically integrated ground truth (measured in #544). This adds the NORM.DIST equivalent invited there in 2022.

`normalDistribution(x, mean, standardDeviation, cumulative)` mirrors the spreadsheet signature: the probability density by default, the cumulative probability via `0.5 * (1 + errorFunction(z / Math.SQRT2))` when `cumulative` is true — within 4.2e-8 of ground truth over z ∈ [−4, 4], versus 2.0e-3 for the table route. Excel's documented examples check out: `normalDistribution(42, 40, 1.5, true)` → 0.90878878 (Excel documents 0.9087888) and `...false` → 0.10934005 (Excel documents 0.10934).

## Design decisions

- `cumulative` is a default parameter (`cumulative = false`), and input types are not validated, per review. An earlier revision threw on a non-boolean `cumulative`; that check and its test were removed in aca2165.
- `standardDeviation <= 0` throws, in the repo's `FUNCTION requires …` error style.
- Deliberately unchanged: `cumulativeStdNormalProbability`, `standardNormalTable`, and `errorFunction`. This adds the missing function; it does not alter existing routes.

## Limitations

Cumulative precision is inherited from `errorFunction`'s Abramowitz–Stegun-type approximation (absolute error below 1.5e-7). In particular `normalDistribution(mean, mean, sd, true)` returns 0.499999985 rather than exactly 0.5, because the approximation gives erf(0) ≈ 3.1e-8. The test at the mean point asserts within 1e-7 and documents this rather than papering over it.

## Testing

Fail-before: the function does not exist on `main` — `git show upstream/main:index.js` contains no reference to `normal_distribution`.

Pass-after, re-run at `aca2165`: `npm test` runs tsc, biome, documentation lint, and the node:test suite — **302/302 tests (294 existing + 8 new), 0 failures**. Reference values were computed independently of the library's own `errorFunction`, using the C standard library's `erf` (via Python's `math.erf`), plus Excel's documented NORM.DIST examples.

Merges cleanly into current `main` (`7643ea9`); GitHub reports MERGEABLE/CLEAN and all three checks pass at `aca2165`.

---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*

