### PR TITLE
docs(jsdoc): correct interquartileRange and weightedQuantile example values

### DIFF
--- a/.changeset/example-values.md
+++ b/.changeset/example-values.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Correct two JSDoc example values that the implementation does not produce: `interquartileRange([0, 1, 2, 3])` returns 1.5 under the type-7 quantile interpolation the library switched to, not the documented 2, and `weightedQuantile([1, 2, 3], [1, 1, 2], 0.5)` returns 2 — the value its own tests assert — not the documented 3. Documentation-only; runtime behavior is untouched.

--- a/src/interquartile_range.js
+++ b/src/interquartile_range.js
@@ -10,7 +10,7 @@ import quantile from "./quantile.js";
  * @returns {number} interquartile range: the span between lower and upper quartile,
  * 0.25 and 0.75
  * @example
- * interquartileRange([0, 1, 2, 3]); // => 2
+ * interquartileRange([0, 1, 2, 3]); // => 1.5
  */
 function interquartileRange(x) {
     // Interquartile range is the span between the upper quartile,

--- a/src/weighted_quantile.js
+++ b/src/weighted_quantile.js
@@ -15,7 +15,7 @@ import validateWeightedInput from "./validate_weighted_input.js";
  * @throws {Error} if x is empty, weights is a different length than x, all weights are zero, a weight is negative, or p is outside of the range from 0 to 1
  * @returns {number} weighted quantile
  * @example
- * weightedQuantile([1, 2, 3], [1, 1, 2], 0.5); // => 3
+ * weightedQuantile([1, 2, 3], [1, 1, 2], 0.5); // => 2
  */
 function weightedQuantile(x, weights, p) {
     const totalWeight = validateWeightedInput(x, weights, "weightedQuantile");


### PR DESCRIPTION
## Summary

Executing every documented `@example` with an expected-output annotation against the library surfaced two documented values the implementation does not produce:

- `interquartileRange([0, 1, 2, 3])` returns 1.5 since the switch to type-7 quantile interpolation (#783); the example still shows the pre-#783 value 2.
- `weightedQuantile([1, 2, 3], [1, 1, 2], 0.5)` returns 2 — the value the function's own prose defines and its tests assert — but the example introduced with it (#790) says 3.

## What is deliberately unchanged

No runtime code. In both cases the implementation is the side that is right: `interquartileRange` matches the intended #783 behavior, and `weightedQuantile` matches its own spec sentence and test suite.

## Testing

`pnpm test` on the branch, re-run 2026-08-15: tsc, biome, documentation lint, and the node:test suite all pass — **301/301 tests, 0 failures**. Branch is based on current `main` (`0c33928`).

Documentation-only, so no failing-before test is possible; the fail-before evidence is executing the two documented examples, which return 1.5 and 2 where the docs claim 2 and 3. Patch changeset included.

---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*
