### PR TITLE
docs(jsdoc): repair quantileRank, jenks, and kMeansCluster rendering

### DIFF
--- a/.changeset/jsdoc-rendering.md
+++ b/.changeset/jsdoc-rendering.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Repair JSDoc that misrenders on the documentation site: `quantileRank` and `quantileRankSorted` now document their `value` parameter (it was missing, and the `@returns` description read "value value"), `jenks`'s example is tagged `@example` so it renders as an example instead of leaking into the `@returns` description, and `kMeansCluster`'s documented example output gets the missing comma that made it invalid JavaScript. Documentation-only; runtime behavior is untouched.

--- a/src/jenks.js
+++ b/src/jenks.js
@@ -14,6 +14,7 @@ import jenksMatrices from "./jenks_matrices.js";
  * @param {Array<number>} data input data, as an array of number values
  * @param {number} nClasses number of desired classes
  * @returns {Array<number>} array of class break positions
+ * @example
  * // split data into 3 break points
  * jenks([1, 2, 4, 5, 7, 9, 10, 20], 3) // = [1, 7, 20, 20]
  */

--- a/src/k_means_cluster.js
+++ b/src/k_means_cluster.js
@@ -18,7 +18,7 @@ import sample from "./sample.js";
  * @throws {Error} If any centroids wind up friendless (i.e., without associated points).
  *
  * @example
- * kMeansCluster([[0.0, 0.5], [1.0, 0.5]], 2); // => {labels: [0, 1], centroids: [[0.0, 0.5], [1.0 0.5]]}
+ * kMeansCluster([[0.0, 0.5], [1.0, 0.5]], 2); // => {labels: [0, 1], centroids: [[0.0, 0.5], [1.0, 0.5]]}
  */
 function kMeansCluster(points, numCluster, randomSource = Math.random) {
     let oldCentroids = null;

--- a/src/quantile_rank.js
+++ b/src/quantile_rank.js
@@ -8,7 +8,8 @@ import quantileRankSorted from "./quantile_rank_sorted.js";
  * instead.
  *
  * @param {Array<number>} x input
- * @returns {number} value value
+ * @param {number} value the value for which to find the quantile rank
+ * @returns {number} the quantile rank
  * @example
  * quantileRank([4, 3, 1, 2], 3); // => 0.75
  * quantileRank([4, 3, 2, 3, 1], 3); // => 0.7

--- a/src/quantile_rank_sorted.js
+++ b/src/quantile_rank_sorted.js
@@ -6,7 +6,8 @@
  * this information in logarithmic time.
  *
  * @param {Array<number>} x input
- * @returns {number} value value
+ * @param {number} value the value for which to find the quantile rank
+ * @returns {number} the quantile rank
  * @example
  * quantileRankSorted([1, 2, 3, 4], 3); // => 0.75
  * quantileRankSorted([1, 2, 3, 3, 4], 3); // => 0.7


### PR DESCRIPTION
## Summary

Three JSDoc blocks misrender on the documentation site, found by comparing every `@param` list against its function's signature and executing the documented examples:

- `quantileRank` and `quantileRankSorted` take `(x, value)` but document only `x`, and their `@returns` line reads "value value", so the site presents a one-argument signature.
- `jenks`'s example lines carry no `@example` tag, so they leak into its `@returns` description.
- `kMeansCluster`'s documented example output was missing a comma (`[1.0 0.5]`), making it invalid JavaScript.

## What is deliberately unchanged

No runtime code, and no documented values — `jenks`'s example output `[1, 7, 20, 20]` was verified correct by running it; it only needed the tag.

## Testing

`pnpm test` on the branch, re-run 2026-08-15: tsc, biome, documentation lint, node:test — **301/301 tests, 0 failures**. Based on current `main` (`0c33928`). Documentation-only; no failing-before test is possible. Patch changeset included.


---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*
