### PR TITLE
fix(types): declare jenks return type as number[] | null

### DIFF
--- a/.changeset/jenks-null-return-type.md
+++ b/.changeset/jenks-null-return-type.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Declare that `jenks` can return `null`. The implementation returns `null` whenever `nClasses` is greater than the number of data points — since the function's introduction — but the type declaration promised a plain `number[]`, so TypeScript consumers under `strictNullChecks` got no warning before dereferencing the result. Runtime behavior is unchanged; only the declaration and docstring now state the `null` case.

--- a/src/jenks.d.ts
+++ b/src/jenks.d.ts
@@ -1,6 +1,9 @@
 /**
  * https://simple-statistics.github.io/docs/#jenks
  */
-declare function jenks(data: readonly number[], nClasses: number): number[];
+declare function jenks(
+    data: readonly number[],
+    nClasses: number
+): number[] | null;
 
 export default jenks;

--- a/src/jenks.js
+++ b/src/jenks.js
@@ -13,7 +13,8 @@ import jenksMatrices from "./jenks_matrices.js";
  *
  * @param {Array<number>} data input data, as an array of number values
  * @param {number} nClasses number of desired classes
- * @returns {Array<number>} array of class break positions
+ * @returns {Array<number> | null} array of class break positions, or null
+ * when nClasses is greater than the number of data points
  * // split data into 3 break points
  * jenks([1, 2, 4, 5, 7, 9, 10, 20], 3) // = [1, 7, 20, 20]
  */


### PR DESCRIPTION
## Summary

`jenks(data, nClasses)` returns `null` whenever `nClasses` is greater than the number of data points — since the function's introduction — but the type declaration promises `number[]`. Under `strictNullChecks` a consumer dereferences the result with no warning and hits a runtime `TypeError`. Same class as #823. The declaration is now `number[] | null`, and the docstring states the null case.

## What is deliberately unchanged

Runtime behavior, and the null contract itself — whether returning null rather than throwing is the right design is a separate question this PR does not touch.

## Testing / limitations

The repo's `tsconfig` has no `strictNullChecks`, so **no failing-before test is possible in-repo** (`test/types.ts` cannot discriminate this). A discriminating consumer compiled with `tsc --strict` shows it instead: before, an unguarded `jenks([1, 2, 3], 5).length` compiles silently — and that call returns `null` at runtime (verified) — after, it fails with `TS2531: Object is possibly 'null'`, and a null-guarded version compiles.

`pnpm test` on the branch, re-run 2026-08-15: **301/301 tests, 0 failures**. Based on current `main` (`0c33928`). Patch changeset included.

---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*
