### PR TITLE
fix(types): make approxEqual tolerance parameter optional

### DIFF
--- a/.changeset/approx-equal-optional-tolerance.md
+++ b/.changeset/approx-equal-optional-tolerance.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Make `approxEqual`'s `tolerance` parameter optional in its type declaration. The implementation defaults it to the library's `epsilon` (0.0001), but the declaration required all three arguments, so TypeScript rejected the two-argument call the runtime supports. Runtime behavior is unchanged.

--- a/src/approx_equal.d.ts
+++ b/src/approx_equal.d.ts
@@ -4,7 +4,7 @@
 declare function approxEqual(
     actual: number,
     expected: number,
-    tolerance: number
+    tolerance?: number
 ): boolean;
 
 export default approxEqual;

--- a/src/approx_equal.js
+++ b/src/approx_equal.js
@@ -6,7 +6,7 @@ import relativeError from "./relative_error.js";
  *
  * @param {number} actual The value to be tested.
  * @param {number} expected The reference value.
- * @param {number} tolerance The acceptable relative difference.
+ * @param {number} [tolerance=epsilon] The acceptable relative difference.
  * @return {boolean} Whether numbers are within tolerance.
  */
 function approxEqual(actual, expected, tolerance = epsilon) {


### PR DESCRIPTION
## Summary

`approxEqual(actual, expected, tolerance = epsilon)` defaults its third argument, but the declaration requires it, so TypeScript rejects the two-argument call the runtime supports: `error TS2554: Expected 3 arguments, but got 2`. The declaration is now `tolerance?: number`, and the JSDoc documents the default.

## What is deliberately unchanged

Runtime behavior; the default remains the library's `epsilon` (0.0001).

## Testing / limitations

**No failing-before test is possible in-repo** (`test/types.ts` compiles without the strictness to discriminate this). A discriminating consumer shows it: `tsc --strict` on `approxEqual(1, 1.0000001)` fails with TS2554 before this change and compiles after, and the two-argument call runs correctly at runtime (verified).

`pnpm test` on the branch, re-run 2026-08-15: **301/301 tests, 0 failures**. Based on current `main` (`0c33928`). Patch changeset included.

---

*This is one of six small, independent PRs I'm opening. They touch different functions and have no ordering dependency between them — merge, request changes on, or close any of them individually without regard to the others.*
