### PR TITLE
fix(types): correct the alternative parameter in the permutationTest declaration

### DIFF
--- a/.changeset/permutation-test-alternative-type.md
+++ b/.changeset/permutation-test-alternative-type.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Correct the third parameter of the `permutationTest` type declaration. It was named `string` and typed `string`, so TypeScript consumers saw `permutationTest(sampleX, sampleY, string?: string, ...)` with no indication of which values are accepted. It is now `alternative?: "two_side" | "greater" | "less"`, matching the JSDoc and the three values the implementation accepts before it throws. Runtime behavior is unchanged. The rename is not breaking, since TypeScript binds parameters positionally, but the narrowed type will newly reject a call that passes an arbitrary `string` — such a call already threw at runtime.

--- a/src/permutation_test.d.ts
+++ b/src/permutation_test.d.ts
@@ -4,7 +4,7 @@
 declare function permutationTest(
     sampleX: readonly number[],
     sampleY: readonly number[],
-    string?: string,
+    alternative?: "two_side" | "greater" | "less",
     k?: number,
     randomSource?: () => number
 ): number;


### PR DESCRIPTION
Related: #828

`src/permutation_test.d.ts` names its third parameter `string` and types it `string`, so TypeScript consumers see `permutationTest(sampleX, sampleY, string?: string, ...)` with no indication of which values are accepted. The implementation takes `'two_side'`, `'greater'` or `'less'` and throws on anything else.

This surfaced from #828: the JSDoc there now reads `{'two_side'|'greater'|'less'}` while the declaration still said `string`, so the two disagreed in-tree.

<details>
<summary>measured both directions, repo's own tsc, <code>--skipLibCheck --noEmit</code></summary>

```ts
permutationTest(x, y, "nonsense");
```

```
with this change:  error TS2345: Argument of type '"nonsense"' is not assignable
                   to parameter of type '"greater" | "less" | "two_side" | undefined'
before it:         no error
```
</details>

The rename is not breaking, since TypeScript binds positionally. The narrowing will newly reject a call passing an arbitrary `string`, which already threw at runtime.

I checked all 93 `.d.ts` files against the JSDoc of the function each declares: this is the only parameter-name mismatch, and there are no arity mismatches.

Checks run: `tsc --noEmit`, `biome check`, `documentation lint src`, and `npm test` at 301 passed.
