### PR TITLE
fix(geometric-mean): keep the mean finite when the product leaves range

### DIFF
--- a/.changeset/geometric-mean-product-range.md
+++ b/.changeset/geometric-mean-product-range.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `geometricMean` returning `Infinity` or `0` for inputs whose geometric mean is perfectly representable. The running product left floating-point range long before the mean did, so 500 values of `1e10` overflowed the product to `Infinity` and returned `Infinity` instead of `1e10`, and 500 values of `1e-10` underflowed it to `0` and returned `0` instead of `1e-10`. The product is now only used when it stays in range; when it overflows or underflows the mean is computed in log space instead, matching the approach `logAverage` already uses for the same quantity. Inputs whose product is representable keep their exact previous result, and an input containing a zero still returns `0`.

--- a/src/geometric_mean.js
+++ b/src/geometric_mean.js
@@ -39,6 +39,7 @@ function geometricMean(x) {
 
     // the starting value.
     let value = 1;
+    let containsZero = false;
 
     for (let i = 0; i < x.length; i++) {
         // the geometric mean is only valid for positive numbers
@@ -48,8 +49,29 @@ function geometricMean(x) {
             );
         }
 
+        if (x[i] === 0) {
+            containsZero = true;
+        }
+
         // repeatedly multiply the value by each number
         value *= x[i];
+    }
+
+    if (containsZero) {
+        return 0;
+    }
+
+    // The running product leaves floating-point range long before the mean
+    // does: 500 copies of 1e10 overflow the product to Infinity even though
+    // the mean is exactly 1e10, and 500 copies of 1e-10 underflow it to 0.
+    // Only in that case fall back to log space, so every input whose product
+    // is representable keeps its exact product-based result.
+    if (value === 0 || !Number.isFinite(value)) {
+        let logSum = 0;
+        for (let i = 0; i < x.length; i++) {
+            logSum += Math.log(x[i]);
+        }
+        return Math.exp(logSum / x.length);
     }
 
     return Math.pow(value, 1 / x.length);

--- a/test/geometric_mean.test.js
+++ b/test/geometric_mean.test.js
@@ -27,4 +27,20 @@ describe("geometric mean", function () {
             assert.fail("geometric mean of array containing zero is not zero");
         }
     });
+
+    it("is unaffected when the running product leaves range", function () {
+        // The mean stays representable long after the product does not:
+        // 500 copies of 1e10 give a product of 1e5000, but a mean of 1e10.
+        const big = ss.geometricMean(new Array(500).fill(1e10));
+        assert.ok(
+            Math.abs(big - 1e10) <= 1e10 * 1e-9,
+            "expected about 1e10, got " + big
+        );
+
+        const small = ss.geometricMean(new Array(500).fill(1e-10));
+        assert.ok(
+            Math.abs(small - 1e-10) <= 1e-10 * 1e-9,
+            "expected about 1e-10, got " + small
+        );
+    });
 });


### PR DESCRIPTION
## What broke

`geometricMean` multiplies every element into a running product and only takes the n-th root at the end, so the intermediate product leaves double range long before the answer does. The function returns `Infinity` or `0` for inputs whose geometric mean is perfectly representable.

The clearest way to see it is that this repo already contains the correct algorithm. `logAverage` in `src/log_average.js` computes the same mathematical quantity in log space and does not overflow:

| input | `geometricMean` | `logAverage` |
|---|---|---|
| `[4, 9]` | 6 | 6 |
| `[1,2,3,4,5]` | 2.605171084697352 | 2.6051710846973517 |
| 500 x `1e10` | **Infinity** | 9999999999.998085 |
| 200 x `1e300` | **Infinity** | 9.999999999980437e+299 |
| 500 x `1e-10` | **0** | 1.0000000000001915e-10 |

They agree on every in-range input and diverge exactly where the naive product leaves range. The true geometric mean of 500 copies of `1e10` is `1e10`.

## The change

The arithmetic is not replaced. The original product path stays, and a log-space fallback runs only when the intermediate product actually leaves range, meaning it hit `0` or a non-finite value. Every input whose product is representable keeps its **bit-identical** previous result.

That matters here because the existing tests assert exact equality, for example `assert.equal(ss.geometricMean([4, 1, 1/32]), 0.5)`. A straight log-space rewrite returns `0.4999999999999999` and breaks the suite. Guarding the fallback means there is no precision change to disclose at all, rather than a 1-ulp shift to apologise for.

Zero is distinguished from underflow explicitly, so `geometricMean([0, 1, 2])` still returns 0.

## Verified

Node v24.18.0, Windows 11.

- The new test fails on unmodified `src/geometric_mean.js` with `expected about 1e10, got Infinity`, and passes with the change. I checked that by restoring only that file from `main` and re-running, so the failure is real and not a stale import.
- Full suite on this branch: **302 tests, 302 pass, 0 fail**.
- `npm run lint` clean, including the `documentation lint` postlint step.
- Differential run against the unpatched original over **200,000 generated inputs**, lengths 1 to 8, magnitudes spanning `1e-300` to `1e300` plus exact `0` and `1`: of the 108,748 inputs where the original returned a usable finite non-zero value, the patched version returned an `Object.is` identical result for **all 108,748**. 40,102 inputs that previously returned `Infinity` or `0` now return a finite value. **Zero regressions.**
- A changeset is included, `patch`.

Values were checked against exact BigInt arithmetic with an integer Newton square root, so the reference could not share the bug under test, plus closed-form cases that need no reference at all: the geometric mean of n copies of v is exactly v.
