### PR TITLE
fix(root-mean-square): keep the result finite when the squares leave range

### DIFF
--- a/.changeset/root-mean-square-square-range.md
+++ b/.changeset/root-mean-square-square-range.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `rootMeanSquare` returning `Infinity` or `0` for inputs whose root mean square is perfectly representable. Squaring leaves floating-point range well before the result does, so `[1e200]` squared to `Infinity` and returned `Infinity` instead of `1e200`, and `[1e-200]` squared to `0` and returned `0` instead of `1e-200`. When the sum of squares overflows or underflows, the values are now divided through by the largest magnitude before squaring and the result scaled back, so the answer stays in range. Inputs whose squares are representable keep their exact previous result, and an all-zero input still returns `0`.

--- a/src/root_mean_square.js
+++ b/src/root_mean_square.js
@@ -22,6 +22,33 @@ function rootMeanSquare(x) {
         sumOfSquares += Math.pow(x[i], 2);
     }
 
+    // Squaring leaves floating-point range well before the result does:
+    // 1e200 squares to Infinity even though its root mean square is 1e200,
+    // and 1e-200 squares to 0 even though its root mean square is 1e-200.
+    // Only in those cases divide through by the largest magnitude first, so
+    // every input whose squares are representable keeps its exact result.
+    if (sumOfSquares === 0 || !Number.isFinite(sumOfSquares)) {
+        let largest = 0;
+        for (let i = 0; i < x.length; i++) {
+            const magnitude = Math.abs(x[i]);
+            if (magnitude > largest) {
+                largest = magnitude;
+            }
+        }
+
+        // every value was zero, so the root mean square is zero
+        if (largest === 0 || !Number.isFinite(largest)) {
+            return Math.sqrt(sumOfSquares / x.length);
+        }
+
+        let scaledSumOfSquares = 0;
+        for (let i = 0; i < x.length; i++) {
+            scaledSumOfSquares += Math.pow(x[i] / largest, 2);
+        }
+
+        return largest * Math.sqrt(scaledSumOfSquares / x.length);
+    }
+
     return Math.sqrt(sumOfSquares / x.length);
 }
 

--- a/test/root_mean_square.test.js
+++ b/test/root_mean_square.test.js
@@ -19,4 +19,22 @@ describe("root_mean_square", function () {
             ss.rootMeanSquare([]);
         });
     });
+
+    it("is unaffected when the squares leave range", function () {
+        // The root mean square of n copies of a value is that value, so each
+        // of these is representable even though the squares are not.
+        assert.equal(ss.rootMeanSquare([1e200]), 1e200);
+        assert.equal(ss.rootMeanSquare([1e300, 1e300]), 1e300);
+        assert.equal(ss.rootMeanSquare([1e-200]), 1e-200);
+
+        const mixed = ss.rootMeanSquare([3e200, 4e200]);
+        assert.ok(
+            Math.abs(mixed - 3.5355339059327374e200) <=
+                3.5355339059327374e200 * 1e-9,
+            "expected about 3.54e200, got " + mixed
+        );
+
+        // all-zero input still has a root mean square of zero
+        assert.equal(ss.rootMeanSquare([0, 0]), 0);
+    });
 });


### PR DESCRIPTION
## What broke

`rootMeanSquare` accumulates `Math.pow(x[i], 2)`, which leaves double range for `|x| > ~1.34e154` and flushes to zero for very small values, even when the RMS itself is perfectly representable.

| input | returns | correct | note |
|---|---|---|---|
| `[1e200]` | **Infinity** | 1e+200 | the RMS of a single value is that value |
| `[3e200, 4e200]` | **Infinity** | 3.5355339059327374e+200 | well inside range |
| `[1e300, 1e300]` | **Infinity** | 1e+300 | |
| `[1e-200]` | **0** | 1e-200 | underflow, not just overflow |
| `[3, 4]` | 3.5355339059327378 | 3.5355339059327378 | unaffected |

## The change

The arithmetic is not replaced. The original path stays, and a scale-factored fallback runs only when the accumulated sum of squares actually leaves range, meaning it hit `0` or a non-finite value. The fallback factors out `max(|x|)` before squaring, hypot style, and returns 0 when that maximum is 0.

Every input whose sum of squares is representable keeps its **bit-identical** previous result, which is why the existing exact-equality assertions such as `rootMeanSquare([1, 1]) === 1` still pass untouched.

## Verified

Node v24.18.0, Windows 11.

- The new test fails on unmodified `src/root_mean_square.js` with `actual: Infinity, expected: 1e+200`, and passes with the change. I checked that by restoring only that file from `main` and re-running.
- Full suite on this branch: **302 tests, 302 pass, 0 fail**.
- `npm run lint` clean, including the `documentation lint` postlint step.
- Differential run against the unpatched original over **200,000 generated inputs**, signed, lengths 1 to 8, magnitudes spanning `1e-300` to `1e300` plus exact `0`: of the 95,810 inputs where the original returned a usable finite non-zero value, the patched version returned an `Object.is` identical result for **all 95,810**. 102,515 inputs that previously returned `Infinity` or `0` now return a finite value. **Zero regressions.**
- Property test with no reference implementation involved: `rootMeanSquare(k*x)` must equal `k*rootMeanSquare(x)` exactly for `k` an exact power of two. **18,042 scalings** with exponents in `[-100, 100]`, **0 violations**. This catches a scaling error in the new branch that a reference-based test could miss if the reference shared the same mistake.
- A changeset is included, `patch`.

One honest limit: for `[1e300, 1e300]` the BigInt cross-check overflowed at its own final `Number()` conversion, so the authority for that case is the closed-form identity that the RMS of n copies of v is exactly `|v|`, not the BigInt harness.

## Note on ordering

This is a sibling of #837, which fixes the same class of problem in `geometricMean`. They touch different files and neither depends on the other, so they can land in either order.
