### PR TITLE
docs(jsdoc): make kMeansCluster's example reproducible

### DIFF
--- a/.changeset/kmeanscluster-example-reproducible.md
+++ b/.changeset/kmeanscluster-example-reproducible.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+`kMeansCluster`'s documented `@example` calls the function without a `randomSource`, so it falls back to `Math.random` and picks its initial centroids from a random shuffle of the input points. Running the exact example as written matches the documented `{labels: [0, 1], ...}` output only about half the time; the other half it comes back as `{labels: [1, 0], ...}` with the centroids swapped to match. The example now passes a fixed `randomSource`, the same technique the test suite already uses for this function, so it reproduces its documented output every time. Runtime behavior of `kMeansCluster` itself is untouched.

--- a/src/k_means_cluster.js
+++ b/src/k_means_cluster.js
@@ -18,7 +18,10 @@ import sample from "./sample.js";
  * @throws {Error} If any centroids wind up friendless (i.e., without associated points).
  *
  * @example
- * kMeansCluster([[0.0, 0.5], [1.0, 0.5]], 2); // => {labels: [0, 1], centroids: [[0.0, 0.5], [1.0, 0.5]]}
+ * // a fixed randomSource makes the initial centroid choice, and so the
+ * // cluster order, reproducible; with the default Math.random the labels
+ * // below could just as well come back as [1, 0]
+ * kMeansCluster([[0.0, 0.5], [1.0, 0.5]], 2, () => 0.9999); // => {labels: [0, 1], centroids: [[0.0, 0.5], [1.0, 0.5]]}
  */
 function kMeansCluster(points, numCluster, randomSource = Math.random) {
     let oldCentroids = null;

--- a/test/k_means_cluster.test.js
+++ b/test/k_means_cluster.test.js
@@ -58,6 +58,23 @@ describe("k-means clustering test", function () {
         ]);
     });
 
+    it("The documented example is reproducible with a fixed randomSource", function () {
+        // Without a randomSource, kMeansCluster falls back to Math.random,
+        // so which point seeds which cluster - and therefore whether the
+        // labels come back as [0, 1] or [1, 0] - is not guaranteed. This
+        // pins the exact call shown in the function's JSDoc @example.
+        const points = Object.freeze([
+            [0.0, 0.5],
+            [1.0, 0.5]
+        ]);
+        const { labels, centroids } = ss.kMeansCluster(points, 2, () => 0.9999);
+        assert.deepEqual(labels, [0, 1]);
+        assert.deepEqual(centroids, [
+            [0.0, 0.5],
+            [1.0, 0.5]
+        ]);
+    });
+
     it("Base case of one value", function () {
         assert.throws(() => {
             ss.kMeansCluster([1], 2, nonRNG);


### PR DESCRIPTION
## Summary

`kMeansCluster`'s `@example` calls the function without a `randomSource`, so it falls back to `Math.random`. The initial centroid pick then decides which point seeds cluster 0 vs cluster 1, so running the example exactly as written matches the documented `{labels: [0, 1], ...}` output only about half the time; the other half it comes back reversed.

## Changes

- Pass a fixed `randomSource` in the example, the same technique the test suite already uses for this exact input (`test/k_means_cluster.test.js`'s `nonRNG`).
- Add a test pinning that literal example call and its output.
- Patch changeset. No change to `kMeansCluster` itself.

## Testing

Ran the original example 200 times: 88/200 did not match the documented output. With the fixed `randomSource`, 200/200 match. `pnpm test` (tsc, biome, `documentation lint`, node:test): 311/311 pass, up from 310.
