### PR TITLE
feat(ckmeans): add ckmeansBreaks for class break output

### DIFF
--- a/.changeset/ckmeans-breaks.md
+++ b/.changeset/ckmeans-breaks.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+Add `ckmeansBreaks(x, nClasses)`, returning Ckmeans clustering results as class breaks in the same `[min, ...breaks, max]` shape `equalIntervalBreaks` uses, so the two are easy to compare. Requested in #273: `ckmeans` itself returns clusters, which is inconvenient when the caller only wants break positions for choropleth-style classification.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@
 export { default as addToMean } from "./src/add_to_mean";
 export { default as chunk } from "./src/chunk";
 export { default as ckmeans } from "./src/ckmeans";
+export { default as ckmeansBreaks } from "./src/ckmeans_breaks";
 export { default as coefficientOfVariation } from "./src/coefficient_of_variation";
 export { default as combinations } from "./src/combinations";
 export { default as combinationsReplacement } from "./src/combinations_replacement";

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
 export { default as addToMean } from "./src/add_to_mean.js";
 export { default as chunk } from "./src/chunk.js";
 export { default as ckmeans } from "./src/ckmeans.js";
+export { default as ckmeansBreaks } from "./src/ckmeans_breaks.js";
 export { default as coefficientOfVariation } from "./src/coefficient_of_variation.js";
 export { default as combinations } from "./src/combinations.js";
 export { default as combinationsReplacement } from "./src/combinations_replacement.js";

--- a/src/ckmeans_breaks.js
+++ b/src/ckmeans_breaks.js
@@ -1,0 +1,28 @@
+import ckmeans from "./ckmeans.js";
+
+/**
+ * Given an array of x, this will use Ckmeans clustering to compute
+ * class breaks, in the same `[min, ...breaks, max]` shape that
+ * `equalIntervalBreaks` returns. Unlike `equalIntervalBreaks`, which
+ * divides the range of the data evenly, each internal break here is
+ * the smallest value of the cluster it starts, so classes group
+ * together values that Ckmeans found to be most alike: a value `v`
+ * falls into class `i` when `breaks[i] <= v < breaks[i + 1]`, and the
+ * last class also includes the maximum value.
+ *
+ * @param {Array<number>} x an array of number values
+ * @param {number} nClasses number of desired classes
+ * @returns {Array<number>} array of class break positions
+ * @example
+ * ckmeansBreaks([-1, 2, -1, 2, 4, 5, 6, -1, 2, -1], 3); // => [-1, 2, 4, 6]
+ */
+function ckmeansBreaks(x, nClasses) {
+    const clusters = ckmeans(x, nClasses);
+    const lastCluster = clusters[clusters.length - 1];
+
+    return clusters
+        .map((cluster) => cluster[0])
+        .concat(lastCluster[lastCluster.length - 1]);
+}
+
+export default ckmeansBreaks;

--- a/test/ckmeans_breaks.test.js
+++ b/test/ckmeans_breaks.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { ckmeansBreaks } from "../index.js";
+
+it("ckmeansBreaks", function () {
+    assert.deepEqual(
+        ckmeansBreaks(Object.freeze([-1, 2, -1, 2, 4, 5, 6, -1, 2, -1]), 3),
+        [-1, 2, 4, 6],
+        "breaks are the first value of each cluster, plus the max"
+    );
+
+    assert.deepEqual(
+        ckmeansBreaks([1, 2, 3, 4, 5, 6], 1),
+        [1, 6],
+        "one class always returns [min, max], like equalIntervalBreaks"
+    );
+
+    assert.deepEqual(
+        ckmeansBreaks([5], 1),
+        [5, 5],
+        "single-value input still returns an nClasses + 1 length array"
+    );
+
+    assert.throws(function () {
+        ckmeansBreaks([1, 2], 5);
+    });
+});

--- a/test/types.ts
+++ b/test/types.ts
@@ -27,6 +27,7 @@ ss.chiSquaredGoodnessOfFit(data1019, ss.poissonDistribution, 0.05); //= false
 ss.chiSquaredDistributionTable[60][0.99];
 ss.chunk([1, 2, 3, 4, 5, 6], 2);
 ss.ckmeans([-1, 2, -1, 2, 4, 5, 6, -1, 2, -1], 3);
+ss.ckmeansBreaks([-1, 2, -1, 2, 4, 5, 6, -1, 2, -1], 3); // => [-1, 2, 4, 6]
 ss.combinationsReplacement([1, 2], 2); // => [[1, 1], [1, 2], [2, 2]]
 ss.combinations([1, 2, 3], 2); // => [[1,2], [1,3], [2,3]]
 ss.equalIntervalBreaks([1, 2, 3, 4, 5, 6], 4); // => [1, 2.25, 3.5, 4.75, 6]


### PR DESCRIPTION
Closes #273.

`ckmeans` returns the clusters themselves, which is awkward when the caller only wants break positions. This adds `ckmeansBreaks(x, nClasses)`, returning `[min, ...internal breaks, max]`, the shape `equalIntervalBreaks` already uses:

```js
equalIntervalBreaks([1, 2, 3, 10, 11, 12, 30, 31, 32], 3);  // => [1, 11.33…, 21.67…, 32]
ckmeansBreaks([1, 2, 3, 10, 11, 12, 30, 31, 32], 3);        // => [1, 10, 30, 32]
```

Same shape, with positions placed where the data actually clusters. Each internal break is the smallest value of the cluster it starts, so `breaks[i] <= v < breaks[i + 1]` selects class `i`, and the last class includes the maximum.

**Deliberately unchanged:** `ckmeans` itself. This adds a separate function rather than altering the existing return format, and delegates to `ckmeans` rather than reimplementing the clustering. The function is four lines.

**Two limits, both inherited rather than introduced:**

Length is `ckmeans(x, nClasses).length + 1`, not unconditionally `nClasses + 1`. Given fewer distinct values than `nClasses`, `ckmeans` returns fewer clusters and the array is shorter. `ckmeansBreaks([5, 5], 2)` gives `[5, 5]` where `equalIntervalBreaks([5, 5], 2)` gives `[5, 5, 5]`.

A break repeats when a cluster is a singleton. `ckmeansBreaks([-1,2,-1,2,4,5,6,-1,2,-1], 4)` gives `[-1, 2, 4, 6, 6]`, the final cluster being `[6]`. `equalIntervalBreaks` behaves the same on degenerate input: `[1,1,1,1]` with 3 classes gives `[1,1,1,1]`.

No guard added for either. Both follow from `ckmeans`, and #273 asks for a format, not new validation.

Changeset included, `minor`.
