### PR TITLE
fix(perceptron): stop train from writing through to the caller's array

### DIFF
--- a/.changeset/perceptron-train-aliases-caller-array.md
+++ b/.changeset/perceptron-train-aliases-caller-array.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `PerceptronModel.train` writing through to the caller's feature array. When the feature length did not match the current weight length, `train` assigned the caller's array to `this.weights` directly, so the weight-update loop mutated the caller's data in place and the model kept sharing identity with that array. `train([1, 2, 3], 0)` left the caller holding `[0, 0, 0]`, and a later write to the caller's array silently rewrote the trained weights. `train` now copies the array, matching the defensive copying already used in `shuffle` and `numericSort`.

--- a/src/perceptron.js
+++ b/src/perceptron.js
@@ -80,7 +80,7 @@ class PerceptronModel {
         // it keeps seeing feature arrays of the same length.
         // When it sees a new data shape, it initializes.
         if (features.length !== this.weights.length) {
-            this.weights = features;
+            this.weights = features.slice();
             this.bias = 1;
         }
         // Make a prediction based on current weights.

--- a/test/perceptron.test.js
+++ b/test/perceptron.test.js
@@ -17,6 +17,21 @@ describe("perceptron", function () {
         assert.equal(p.bias, 1);
     });
 
+    it("train does not modify the caller's feature array", function () {
+        const p = new PerceptronModel();
+        const features = [1, 2, 3];
+        p.train(features, 0);
+        assert.deepEqual(features, [1, 2, 3]);
+    });
+
+    it("train does not keep a reference to the caller's array", function () {
+        const p = new PerceptronModel();
+        const features = [1, 2, 3];
+        p.train(features, 1);
+        features[0] = 999;
+        assert.deepEqual(p.weights, [1, 2, 3]);
+    });
+
     it("base case of zero prediction features", function () {
         const p = new PerceptronModel();
         p.train([1, 2, 3], 1);


### PR DESCRIPTION
`PerceptronModel.train` writes through to the array you pass it. `train([1, 2, 3], 0)` leaves the caller holding `[0, 0, 0]`, and the model keeps sharing identity with that array, so a later write to it silently rewrites the trained weights.

When the feature length does not match the current weight length, `train` assigns the caller's array to `this.weights` directly, and the update loop then does `this.weights[i] += gradient * features[i]` through that alias. Fixed by copying on assignment, the pattern `shuffle` and `numericSort` already use.

**Deliberately unchanged:** initialization semantics. Weights still start as the first feature vector and bias still starts at 1. This is a copy, not a different initializer.

**Output is unchanged for callers passing a fresh array per call.** The class example and every existing test give identical weights, bias and predictions either way. Output differs only when a caller reuses one array object across calls, where the old code trained the second call on a vector the first had already zeroed.

Two new tests, both failing before the fix and passing after.

<details>
<summary>Evidence</summary>

Baseline, unmodified `f2a67a3`: `npm test` gives 310 tests, 310 pass, 0 fail.
With this change: 312 tests, 312 pass, 0 fail. `npm run lint` (tsc, biome, documentation lint) exits 0 both times.

Fail-before, new tests against unmodified `src/perceptron.js`:

```
✖ train does not modify the caller's feature array
  actual: [ 0, 0, 0 ]   expected: [ 1, 2, 3 ]
✖ train does not keep a reference to the caller's array
  actual: [ 999, 2, 3 ] expected: [ 1, 2, 3 ]
```

Behaviour comparison, same script run with and without the one-line change:

```
                                  without fix        with fix
class example predictions         0 0 0 1            0 0 0 1
class example weights/bias        [2,1] / -2         [2,1] / -2
"separate one from two"           [1] / -1           [1] / -1
caller reuses one array object    weights [0,0,0]    weights [1,2,3]
                                  caller  [0,0,0]    caller  [1,2,3]
```

Not verified: no benchmark was run, so this claims nothing about performance. The
copy adds one allocation per shape change, not per training call.

</details>

Changeset included, `patch`.
