### PR TITLE
fix(standard-normal-table): correct six entries above z = 2.9

### DIFF
--- a/.changeset/standard-normal-table-precision.md
+++ b/.changeset/standard-normal-table-precision.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Correct six entries at the top of `standardNormalTable`. The table is built from a Taylor series truncated at 15 terms, which falls short of four-decimal precision above z = 2.9: `cumulativeStdNormalProbability(3)` returned 0.9986 where the published value is 0.9987, and z = 2.94, 2.96, 2.98, 3.05 and 3.08 were each low by one in the fourth decimal. Thirty terms converge across the whole domain of the table.

--- a/src/standard_normal_table.js
+++ b/src/standard_normal_table.js
@@ -4,8 +4,10 @@ function cumulativeDistribution(z) {
     let sum = z;
     let tmp = z;
 
-    // 15 iterations are enough for 4-digit precision
-    for (let i = 1; i < 15; i++) {
+    // The series converges more slowly as z grows: 15 terms fall short of
+    // 4-digit precision above z = 2.9. 30 terms converge across the whole
+    // domain of the table below, which ends at z = 3.09.
+    for (let i = 1; i < 30; i++) {
         tmp *= (z * z) / (2 * i + 1);
         sum += tmp;
     }

--- a/test/standard_normal_table.test.js
+++ b/test/standard_normal_table.test.js
@@ -14,4 +14,25 @@ describe("standardNormalTable", function () {
             }
         }
     });
+
+    it("matches published values where the series converges slowest", function () {
+        // Four-decimal values from a published standard normal table. The
+        // series behind the table converges more slowly as z grows, so the
+        // top of its domain is where truncation shows up first.
+        const published = [
+            [2.94, 0.9984],
+            [2.96, 0.9985],
+            [2.98, 0.9986],
+            [3, 0.9987],
+            [3.05, 0.9989],
+            [3.08, 0.999]
+        ];
+        for (const [z, phi] of published) {
+            assert.equal(ss.cumulativeStdNormalProbability(z), phi);
+        }
+    });
+
+    it("negative z stays the complement of positive z", function () {
+        assert.equal(ss.cumulativeStdNormalProbability(-3), 0.0013);
+    });
 });


### PR DESCRIPTION
`cumulativeStdNormalProbability(3)` returns 0.9986. The published value is 0.9987.

`standardNormalTable` is built from a Taylor series truncated at 15 terms. That series converges more slowly as z grows, so the shortfall only reaches the fourth decimal near the top of the table's domain. Six of the 310 entries are low by one there: z = 2.94, 2.96, 2.98, 3.00, 3.05 and 3.08. The negative branch reads the same entries, so `cumulativeStdNormalProbability(-3)` returns 0.0014 instead of 0.0013.

Running the loop to 30 terms corrects all six. The other 304 entries are unchanged.

<details>
<summary>verification</summary>

The same series run to 200 terms as a reference, compared against the shipped table at all 310 entries:

```
z=2.94  shipped 0.9983  converged 0.9984  (raw 0.99835894)
z=2.96  shipped 0.9984  converged 0.9985  (raw 0.99846180)
z=2.98  shipped 0.9985  converged 0.9986  (raw 0.99855876)
z=3.00  shipped 0.9986  converged 0.9987  (raw 0.99865010)
z=3.05  shipped 0.9988  converged 0.9989  (raw 0.99885579)
z=3.08  shipped 0.9989  converged 0.9990  (raw 0.99896500)
mismatches: 6 of 310
```

30 terms is convergence rather than a tuned number: at 30 terms the rounded table is identical to the 200-term run at every one of the 310 entries. At z = 3.00 the partial sums are 0.99863063 (15 terms), 0.99865009 (20), 0.99865010 (30 and beyond).

The added test fails on current main with `0.9983 !== 0.9984` and `0.0014 !== 0.0013`.

Checks on this branch: `npm test` 311 passed and 0 failed, up from 309 on `5c54a63`; `tsc --skipLibCheck --noEmit`, `biome check index.js src test`, `documentation lint src` and `rollup -c` each exit 0, matching the baseline.

</details>

The existing `matches errorFunction` case in `test/cumulative.test.js` compares against `ss.epsilon`, which is 1e-4, and the largest of these errors is 5e-5, so it passed the whole time.
