### PR TITLE
fix(t-test): use the sample standard deviation in tTest

### DIFF
--- a/.changeset/t-test-sample-sd.md
+++ b/.changeset/t-test-sample-sd.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+`tTest` now divides by the sample standard deviation (Bessel's correction), matching the one-sample t statistic in the linked reference, R's `t.test()` and `scipy.stats.ttest_1samp`. Returned statistics are smaller in magnitude than before by `sqrt(n / (n - 1))`, and a sample with fewer than two data points now throws instead of returning `Infinity`.

--- a/src/t_test.js
+++ b/src/t_test.js
@@ -1,5 +1,5 @@
 import mean from "./mean.js";
-import sampleVariance from "./sample_variance.js";
+import sampleStandardDeviation from "./sample_standard_deviation.js";
 
 /**
  * This is to compute [a one-sample t-test](https://en.wikipedia.org/wiki/Student%27s_t-test#One-sample_t-test), comparing the mean
@@ -25,7 +25,7 @@ function tTest(x, expectedValue) {
 
     // The sample standard deviation, with Bessel's correction: the
     // one-sample t statistic divides by s, not the population sigma.
-    const sd = Math.sqrt(sampleVariance(x));
+    const sd = sampleStandardDeviation(x);
 
     // Square root the length of the sample
     const rootN = Math.sqrt(x.length);

--- a/src/t_test.js
+++ b/src/t_test.js
@@ -1,5 +1,5 @@
 import mean from "./mean.js";
-import standardDeviation from "./standard_deviation.js";
+import sampleVariance from "./sample_variance.js";
 
 /**
  * This is to compute [a one-sample t-test](https://en.wikipedia.org/wiki/Student%27s_t-test#One-sample_t-test), comparing the mean
@@ -12,18 +12,20 @@ import standardDeviation from "./standard_deviation.js";
  * a certain level of significance, will let you determine that the
  * null hypothesis can or cannot be rejected.
  *
- * @param {Array<number>} x sample of one or more numbers
+ * @param {Array<number>} x sample of two or more numbers
  * @param {number} expectedValue expected value of the population mean
  * @returns {number} value
+ * @throws {Error} if the sample has fewer than two data points
  * @example
- * tTest([1, 2, 3, 4, 5, 6], 3.385).toFixed(2); // => '0.16'
+ * tTest([1, 2, 3, 4, 5, 6], 3.385).toFixed(2); // => '0.15'
  */
 function tTest(x, expectedValue) {
     // The mean of the sample
     const sampleMean = mean(x);
 
-    // The standard deviation of the sample
-    const sd = standardDeviation(x);
+    // The sample standard deviation, with Bessel's correction: the
+    // one-sample t statistic divides by s, not the population sigma.
+    const sd = Math.sqrt(sampleVariance(x));
 
     // Square root the length of the sample
     const rootN = Math.sqrt(x.length);

--- a/test/t_test.test.js
+++ b/test/t_test.test.js
@@ -5,6 +5,20 @@ import * as ss from "../index.js";
 describe("t test", function () {
     it("can compare a known value to the mean of samples", function () {
         const res = ss.tTest([1, 2, 3, 4, 5, 6], 3.385);
-        assert.equal(res, 0.1649415480881466);
+        assert.equal(res, 0.15057034426283503);
+    });
+
+    it("matches the closed-form statistic for a reference sample", function () {
+        // Worked example from Wikipedia's Standard deviation article:
+        // mean 5, sum of squared deviations 32, so sample variance is
+        // 32 / 7 and t = (5 - 4) / (sqrt(32/7) / sqrt(8)) = sqrt(7) / 2.
+        const res = ss.tTest([2, 4, 4, 4, 5, 5, 7, 9], 4);
+        assert.equal(res, Math.sqrt(7) / 2);
+    });
+
+    it("throws for a sample with fewer than two data points", function () {
+        assert.throws(function () {
+            ss.tTest([5], 3);
+        }, /at least two data points/);
     });
 });


### PR DESCRIPTION
`tTest` divides by the population standard deviation. The one-sample t statistic divides by the sample standard deviation, with Bessel's correction.

`standardDeviation` divides the sum of squared deviations by `n`: `variance.js` says so in its own docstring, "This is an implementation of variance, not sample variance". The statistic on the Wikipedia page this function's JSDoc links to, and what R's `t.test()` and `scipy.stats.ttest_1samp` compute, divides by `n - 1`. `tTestTwoSample` already imports `sampleVariance`, so the two halves of the same test disagreed.

```js
tTest([1, 2, 3, 4, 5, 6], 3.385)
// before: 0.1649415480881466
// after:  0.15057034426283503   <- R, scipy, and the linked reference
```

The statistic was inflated by exactly `sqrt(n / (n - 1))`: about 9.5% at `n = 6`, 22% at `n = 3`. Since a t statistic is looked up against a distribution with `n - 1` degrees of freedom, an inflated statistic yields a p-value that is too small: the error runs in the direction that overstates significance, and it is largest for the small samples a t-test is normally used on.

**Deliberately unchanged:** `standardDeviation`, `variance`, and `tTestTwoSample`. This swaps one import in `t_test.js`; it does not touch the SD functions themselves, and it does not add a p-value (that is #836's job).

**Two things a caller will observe**, both in the changeset:

1. The returned statistic is smaller in magnitude for the same input. The JSDoc example moves from `'0.16'` to `'0.15'`.
2. A sample of fewer than two data points now throws `sampleVariance requires at least two data points` instead of returning `Infinity`. One value leaves no degrees of freedom, so the old return was a division by a zero standard deviation rather than a result. `@param` and a new `@throws` say so.

Tagged `minor`, following `poissonDistribution`/`binomialDistribution` in 7.10.0: a correctness fix that changed returned values, tagged minor with an explicit behavior note. Happy to make it `patch` or `major` if you would rather.

**This also affects #836**, which is mine and still open. `tTestPValue` calls `tTest` and passes the result to a t distribution with `n - 1` degrees of freedom, so it inherits the mismatch: its documented example moves from `0.8755` to `0.8862`. I will update that PR once you have decided on this one, rather than pre-emptively rebasing it onto a change you may not want.

<details>
<summary>Evidence</summary>

The fix-before/fix-after values, run at the PR head:

```
tTest([1,2,3,4,5,6], 3.385) = 0.15057034426283503   toFixed(2) = '0.15'
tTest([5], 3)               throws "sampleVariance requires at least two data points"
```

The new test is anchored to an external reference rather than to the code's output, since pinning the implementation's own value is how the original error survived. `x = [2, 4, 4, 4, 5, 5, 7, 9]` is the worked example from Wikipedia's *Standard deviation* article: mean 5, sum of squared deviations `9+1+1+1+0+0+4+16 = 32`. Against `expectedValue = 4`:

```
sample variance = 32 / (8 - 1) = 32/7
t = (5 - 4) / (sqrt(32/7) / sqrt(8)) = sqrt(7) / 2
```

and the implementation returns that exactly:

```
tTest([2,4,4,4,5,5,7,9], 4) = 1.3228756555322954
Math.sqrt(7) / 2            = 1.3228756555322954   strictly equal, 0 ulp
```

The p-value figures above were computed independently of this library, by adaptive Simpson integration of the Student-t density, so they check the library rather than restate it. Two sanity checks: `p(t = 0, df = 5) = 1.000000`, and `p(t = 2.570582, df = 5) = 0.0500`, the textbook two-sided 5% critical value at 5 degrees of freedom.

</details>
