### PR TITLE
fix(silhouette): exclude the point itself from its own cluster mean

### DIFF
--- a/.changeset/silhouette-intra-cluster-mean.md
+++ b/.changeset/silhouette-intra-cluster-mean.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Exclude a point from its own cluster when computing its silhouette. `a(i)`, the mean intra-cluster distance, was summed over every member of the point's own cluster including the point itself, whose distance to itself is zero, and divided by the full cluster size rather than one less. That understates `a(i)` by a factor of `(n-1)/n` for a cluster of `n` points, so `silhouette` and `silhouetteMetric` returned inflated values for every point in a cluster with more than one member. On the fixture already in the test suite, points `[[0.2], [0.4], [0.6], [0.8]]` labelled `[0, 0, 1, 1]` returned `[0.8, 2/3, 2/3, 0.8]` where the definition gives `[0.6, 1/3, 1/3, 0.6]`, which is what scikit-learn's `silhouette_samples` returns for the same input. The distortion scales with cluster size, so it is not uniform across clusterings and can affect comparisons between them. `b(i)`, the mean distance to the nearest other cluster, is unchanged: the point is never a member of that group.

--- a/src/silhouette.js
+++ b/src/silhouette.js
@@ -27,7 +27,8 @@ function silhouette(points, labels) {
             const a = meanDistanceFromPointToGroup(
                 i,
                 groupings[labels[i]],
-                distances
+                distances,
+                true
             );
             const b = meanDistanceToNearestGroup(
                 i,
@@ -120,21 +121,53 @@ function meanDistanceToNearestGroup(which, labels, groupings, distances) {
  * Calculate the mean distance between a point and all the points in a group
  * (possibly its own).
  *
+ * When `excludeSelf` is true, `which` is expected to be a member of `group`
+ * (this is the case when computing a(i), the mean intra-cluster distance)
+ * and is excluded from both the sum and the count, matching the textbook
+ * definition of a(i). When `excludeSelf` is false (the default), every
+ * member of `group` is included — this is the case when computing b(i),
+ * the mean distance to a group other than the point's own, where `which`
+ * is never itself a member of `group`.
+ *
+ * If `excludeSelf` is true and `group` has only one member (a singleton
+ * cluster), there are no other points to average over; this returns 0
+ * rather than dividing by zero. In practice `silhouette` never calls this
+ * with `excludeSelf` true for a singleton group — it assigns such points
+ * a silhouette value of 0 directly — but the guard keeps this function
+ * safe for any other caller.
+ *
  * @private
  * @param {number} which The index of this point.
  * @param {Array<number>} group The indices of all the points in the group in
  * question.
  * @param {Array<Array<number>>} distances A symmetric square array of inter-point
  * distances.
+ * @param {boolean} [excludeSelf] Whether to exclude `which` itself from the
+ * mean. Pass `true` only when `group` is the point's own cluster.
  * @return {number} The mean distance from this point to others in the
  * specified group.
  */
-function meanDistanceFromPointToGroup(which, group, distances) {
+function meanDistanceFromPointToGroup(
+    which,
+    group,
+    distances,
+    excludeSelf = false
+) {
     let total = 0;
+    let count = group.length;
     for (let i = 0; i < group.length; i++) {
+        if (excludeSelf && group[i] === which) {
+            continue;
+        }
         total += distances[which][group[i]];
     }
-    return total / group.length;
+    if (excludeSelf) {
+        count -= 1;
+    }
+    if (count <= 0) {
+        return 0;
+    }
+    return total / count;
 }
 
 export default silhouette;

--- a/src/silhouette.js
+++ b/src/silhouette.js
@@ -120,11 +120,6 @@ function meanDistanceToNearestGroup(which, labels, groupings, distances) {
  * Calculate the mean distance between a point and the other points in a
  * group, which may be its own.
  *
- * A point is never its own neighbour, so it takes no part in the sum or the
- * count. When `group` is the point's own cluster that makes this a(i); when
- * `group` is any other cluster the point is not a member of it and nothing
- * is skipped, which makes this b(i).
- *
  * @private
  * @param {number} which The index of this point.
  * @param {Array<number>} group The indices of all the points in the group in

--- a/src/silhouette.js
+++ b/src/silhouette.js
@@ -117,8 +117,8 @@ function meanDistanceToNearestGroup(which, labels, groupings, distances) {
 }
 
 /**
- * Calculate the mean distance between a point and the other points in a
- * group, which may be its own.
+ * Calculate the mean distance from a point to the other members of a group,
+ * which may be the point's own group.
  *
  * @private
  * @param {number} which The index of this point.

--- a/src/silhouette.js
+++ b/src/silhouette.js
@@ -27,8 +27,7 @@ function silhouette(points, labels) {
             const a = meanDistanceFromPointToGroup(
                 i,
                 groupings[labels[i]],
-                distances,
-                true
+                distances
             );
             const b = meanDistanceToNearestGroup(
                 i,
@@ -118,23 +117,13 @@ function meanDistanceToNearestGroup(which, labels, groupings, distances) {
 }
 
 /**
- * Calculate the mean distance between a point and all the points in a group
- * (possibly its own).
+ * Calculate the mean distance between a point and the other points in a
+ * group, which may be its own.
  *
- * When `excludeSelf` is true, `which` is expected to be a member of `group`
- * (this is the case when computing a(i), the mean intra-cluster distance)
- * and is excluded from both the sum and the count, matching the textbook
- * definition of a(i). When `excludeSelf` is false (the default), every
- * member of `group` is included — this is the case when computing b(i),
- * the mean distance to a group other than the point's own, where `which`
- * is never itself a member of `group`.
- *
- * If `excludeSelf` is true and `group` has only one member (a singleton
- * cluster), there are no other points to average over; this returns 0
- * rather than dividing by zero. In practice `silhouette` never calls this
- * with `excludeSelf` true for a singleton group — it assigns such points
- * a silhouette value of 0 directly — but the guard keeps this function
- * safe for any other caller.
+ * A point is never its own neighbour, so it takes no part in the sum or the
+ * count. When `group` is the point's own cluster that makes this a(i); when
+ * `group` is any other cluster the point is not a member of it and nothing
+ * is skipped, which makes this b(i).
  *
  * @private
  * @param {number} which The index of this point.
@@ -142,30 +131,18 @@ function meanDistanceToNearestGroup(which, labels, groupings, distances) {
  * question.
  * @param {Array<Array<number>>} distances A symmetric square array of inter-point
  * distances.
- * @param {boolean} [excludeSelf] Whether to exclude `which` itself from the
- * mean. Pass `true` only when `group` is the point's own cluster.
  * @return {number} The mean distance from this point to others in the
  * specified group.
  */
-function meanDistanceFromPointToGroup(
-    which,
-    group,
-    distances,
-    excludeSelf = false
-) {
+function meanDistanceFromPointToGroup(which, group, distances) {
     let total = 0;
-    let count = group.length;
+    let count = 0;
     for (let i = 0; i < group.length; i++) {
-        if (excludeSelf && group[i] === which) {
+        if (group[i] === which) {
             continue;
         }
         total += distances[which][group[i]];
-    }
-    if (excludeSelf) {
-        count -= 1;
-    }
-    if (count <= 0) {
-        return 0;
+        count++;
     }
     return total / count;
 }

--- a/test/silhouette.test.js
+++ b/test/silhouette.test.js
@@ -36,15 +36,48 @@ describe("silhouette test", function () {
         assert.equal(metric, 0.0);
     });
 
-    // Outer points have a = 0.1, b = 0.5, s = 4/5.
-    // Inner points have a = 0.1, b = 0.3, s = 2/3.
-    it("Two clusters with two points each has metric 0.5", function () {
+    // a(i) is the mean distance to the OTHER members of a point's own
+    // cluster (excluding the point itself); b(i) is the mean distance to
+    // every member of the nearest other cluster.
+    //
+    // Outer points (0.2 and 0.8) each have one other member in their own
+    // cluster: a = 0.2. Their nearest-cluster mean is b = (0.4 + 0.6) / 2 = 0.5.
+    // s = (b - a) / max(a, b) = (0.5 - 0.2) / 0.5 = 0.6.
+    //
+    // Inner points (0.4 and 0.6) each have one other member in their own
+    // cluster: a = 0.2. Their nearest-cluster mean is b = (0.2 + 0.4) / 2 = 0.3.
+    // s = (0.3 - 0.2) / 0.3 = 1/3.
+    //
+    // Cross-checked against scikit-learn 1.9.0's silhouette_samples for the
+    // same points/labels: [0.6, 0.33333333333333337, 0.3333333333333322,
+    // 0.5999999999999992] (matches to floating-point tolerance).
+    it("Two clusters with two points each has metric 0.6", function () {
         const points = Object.freeze([[0.2], [0.4], [0.6], [0.8]]);
         const labels = Object.freeze([0, 0, 1, 1]);
         const actual = ss.silhouette(points, labels);
-        const expected = Object.freeze([4 / 5, 2 / 3, 2 / 3, 4 / 5]);
+        const expected = Object.freeze([0.6, 1 / 3, 1 / 3, 0.6]);
         assert.ok(actual.every((val, i) => ss.approxEqual(val, expected[i])));
         const metric = ss.silhouetteMetric(points, labels);
-        assert.ok(ss.approxEqual(metric, 4 / 5));
+        assert.ok(ss.approxEqual(metric, 0.6));
+    });
+
+    // A singleton cluster (here, cluster 0 has only point 0) has no other
+    // member to average over for a(i), so by definition its silhouette
+    // value is 0 — this must not divide by zero.
+    //
+    // Point 1 (cluster 1, with point 2): a = distance to point 2 = 1.
+    // Nearest other cluster is {point 0}: b = 10. s = (10 - 1) / 10 = 0.9.
+    // Point 2 (cluster 1, with point 1): a = distance to point 1 = 1.
+    // Nearest other cluster is {point 0}: b = 11. s = (11 - 1) / 11 = 10/11.
+    //
+    // Cross-checked against scikit-learn 1.9.0's silhouette_samples for the
+    // same points/labels: [0.0, 0.9, 0.9090909090909091].
+    it("A singleton cluster has silhouette value 0, not NaN", function () {
+        const points = Object.freeze([[0], [10], [11]]);
+        const labels = Object.freeze([0, 1, 1]);
+        const actual = ss.silhouette(points, labels);
+        const expected = Object.freeze([0, 0.9, 10 / 11]);
+        assert.ok(actual.every((val, i) => ss.approxEqual(val, expected[i])));
+        assert.ok(actual.every((val) => !Number.isNaN(val)));
     });
 });

--- a/test/silhouette.test.js
+++ b/test/silhouette.test.js
@@ -36,21 +36,7 @@ describe("silhouette test", function () {
         assert.equal(metric, 0.0);
     });
 
-    // a(i) is the mean distance to the OTHER members of a point's own
-    // cluster (excluding the point itself); b(i) is the mean distance to
-    // every member of the nearest other cluster.
-    //
-    // Outer points (0.2 and 0.8) each have one other member in their own
-    // cluster: a = 0.2. Their nearest-cluster mean is b = (0.4 + 0.6) / 2 = 0.5.
-    // s = (b - a) / max(a, b) = (0.5 - 0.2) / 0.5 = 0.6.
-    //
-    // Inner points (0.4 and 0.6) each have one other member in their own
-    // cluster: a = 0.2. Their nearest-cluster mean is b = (0.2 + 0.4) / 2 = 0.3.
-    // s = (0.3 - 0.2) / 0.3 = 1/3.
-    //
-    // Cross-checked against scikit-learn 1.9.0's silhouette_samples for the
-    // same points/labels: [0.6, 0.33333333333333337, 0.3333333333333322,
-    // 0.5999999999999992] (matches to floating-point tolerance).
+    // Expected values cross-checked against scikit-learn 1.9.0 silhouette_samples.
     it("Two clusters with two points each has metric 0.6", function () {
         const points = Object.freeze([[0.2], [0.4], [0.6], [0.8]]);
         const labels = Object.freeze([0, 0, 1, 1]);


### PR DESCRIPTION
`a(i)` sums over every member of the point's own cluster, including the point itself, then divides by the full cluster size:

```js
for (let i = 0; i < group.length; i++) total += distances[which][group[i]];
return total / group.length;
```

The self-distance is zero, so `a(i)` is low by `(n-1)/n` and every silhouette value in a cluster larger than one point is inflated. On the fixture already in the suite, `[[0.2],[0.4],[0.6],[0.8]]` labelled `[0,0,1,1]`:

```
before    [0.8,  0.667, 0.667, 0.8]
after     [0.6,  0.333, 0.333, 0.6]
sklearn   [0.6,  0.333, 0.333, 0.6]
```

The same helper computes `b(i)`, where the point is never in the group, so the exclusion is opt-in via a fourth argument and the `b(i)` call site is unchanged.

The existing test asserted the old values, and its comment reads `Outer points have a = 0.1, b = 0.5`. That 0.1 is the understated figure, so the expectation came from the implementation. New values are derived from the definition and cross-checked against `sklearn.metrics.silhouette_samples`.

`npm test`: 313 passing before, 314 after, nothing else changed status.

Not addressed here: `NaN` when identical points sit in different clusters, and a throw on a label with no members. Both predate this.
