### PR TITLE
fix(inverse-error-function): refine the estimate with Newton's method

### DIFF
--- a/.changeset/inverse-error-function-precision.md
+++ b/.changeset/inverse-error-function-precision.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Refine `inverseErrorFunction` with Newton's method. It returned only the Winitzki approximation, whose round-trip error through `errorFunction` reaches 3.3e-4 against a test tolerance of 4e-4. `probit`, which is built on it, was correspondingly coarse: `probit(0.975)` returned 1.9572 where the standard normal quantile is 1.9600, and the error grew to 1.0e-2 at `probit(0.999)`. Two Newton steps against `errorFunction` bring the round trip to 8.3e-8 and `probit` to within 5.7e-8 of the published quantiles.

--- a/src/inverse_error_function.js
+++ b/src/inverse_error_function.js
@@ -16,24 +16,23 @@ const TWO_OVER_SQRT_PI = 2 / Math.sqrt(Math.PI);
  * @returns {number} estimated inverted value
  */
 function inverseErrorFunction(x) {
+    const a = (8 * (Math.PI - 3)) / (3 * Math.PI * (4 - Math.PI));
+
+    const inv = Math.sqrt(
+        Math.sqrt(
+            Math.pow(2 / (Math.PI * a) + Math.log(1 - x * x) / 2, 2) -
+                Math.log(1 - x * x) / a
+        ) -
+            (2 / (Math.PI * a) + Math.log(1 - x * x) / 2)
+    );
+
     // `errorFunction` is off by a few parts in 1e8 at zero, so the
     // refinement below would walk the exact answer away from it.
     if (x === 0) {
         return 0;
     }
 
-    const a = (8 * (Math.PI - 3)) / (3 * Math.PI * (4 - Math.PI));
-
-    const logTerm = Math.log(1 - x * x);
-    const halfLog = 2 / (Math.PI * a) + logTerm / 2;
-
-    let estimate = Math.sqrt(
-        Math.sqrt(halfLog * halfLog - logTerm / a) - halfLog
-    );
-
-    if (x < 0) {
-        estimate = -estimate;
-    }
+    let estimate = x >= 0 ? inv : -inv;
 
     // At |x| >= 1 the estimate is already infinite or not a number, and
     // there is nothing for the refinement below to converge towards.

--- a/src/inverse_error_function.js
+++ b/src/inverse_error_function.js
@@ -1,27 +1,62 @@
+import errorFunction from "./error_function.js";
+
+const TWO_OVER_SQRT_PI = 2 / Math.sqrt(Math.PI);
+
 /**
  * The Inverse [Gaussian error function](http://en.wikipedia.org/wiki/Error_function)
  * returns a numerical approximation to the value that would have caused
  * `errorFunction()` to return x.
  *
+ * Winitzki's approximation supplies the initial estimate, which is then
+ * refined by [Newton's method](https://en.wikipedia.org/wiki/Newton%27s_method)
+ * against `errorFunction()`. The derivative of the error function is
+ * `2 / sqrt(π) * exp(-x²)`.
+ *
  * @param {number} x value of error function
  * @returns {number} estimated inverted value
  */
 function inverseErrorFunction(x) {
+    // `errorFunction` is off by a few parts in 1e8 at zero, so the
+    // refinement below would walk the exact answer away from it.
+    if (x === 0) {
+        return 0;
+    }
+
     const a = (8 * (Math.PI - 3)) / (3 * Math.PI * (4 - Math.PI));
 
-    const inv = Math.sqrt(
-        Math.sqrt(
-            Math.pow(2 / (Math.PI * a) + Math.log(1 - x * x) / 2, 2) -
-                Math.log(1 - x * x) / a
-        ) -
-            (2 / (Math.PI * a) + Math.log(1 - x * x) / 2)
+    const logTerm = Math.log(1 - x * x);
+    const halfLog = 2 / (Math.PI * a) + logTerm / 2;
+
+    let estimate = Math.sqrt(
+        Math.sqrt(halfLog * halfLog - logTerm / a) - halfLog
     );
 
-    if (x >= 0) {
-        return inv;
-    } else {
-        return -inv;
+    if (x < 0) {
+        estimate = -estimate;
     }
+
+    // At |x| >= 1 the estimate is already infinite or not a number, and
+    // there is nothing for the refinement below to converge towards.
+    if (!Number.isFinite(estimate)) {
+        return estimate;
+    }
+
+    // Two Newton steps take the estimate from the roughly 1e-3 accuracy of
+    // the approximation down to the accuracy of `errorFunction` itself.
+    for (let i = 0; i < 2; i++) {
+        const slope = TWO_OVER_SQRT_PI * Math.exp(-estimate * estimate);
+
+        // Far out in the tails the slope underflows to zero, and a step
+        // divided by it would be infinite. The estimate there is already
+        // as close as this method can bring it.
+        if (slope === 0) {
+            break;
+        }
+
+        estimate -= (errorFunction(estimate) - x) / slope;
+    }
+
+    return estimate;
 }
 
 export default inverseErrorFunction;

--- a/test/inverse_error_function.test.js
+++ b/test/inverse_error_function.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as ss from "../index.js";
+
+describe("inverseErrorFunction", function () {
+    // Reference values obtained by inverting a Maclaurin series expansion of
+    // the error function to machine precision.
+    const reference = [
+        [0.25, 0.22531205501217805],
+        [0.5, 0.47693627620446988],
+        [0.75, 0.81341984759761798],
+        [0.9, 1.163087153676674],
+        [0.95, 1.3859038243496777],
+        [0.99, 1.8213863677184494]
+    ];
+
+    it("matches reference values", function () {
+        for (const [y, expected] of reference) {
+            assert.equal(
+                Math.abs(ss.inverseErrorFunction(y) - expected) < 1e-6,
+                true,
+                "inverseErrorFunction(" + y + ")"
+            );
+        }
+    });
+
+    it("inverts errorFunction", function () {
+        for (let i = -0.99; i <= 0.99; i += 0.01) {
+            assert.equal(
+                Math.abs(ss.errorFunction(ss.inverseErrorFunction(i)) - i) <
+                    1e-6,
+                true,
+                "round trip at " + i
+            );
+        }
+    });
+
+    it("is zero at zero and odd elsewhere", function () {
+        assert.equal(ss.inverseErrorFunction(0), 0);
+        for (const y of [0.1, 0.5, 0.9]) {
+            assert.equal(
+                ss.inverseErrorFunction(-y),
+                -ss.inverseErrorFunction(y)
+            );
+        }
+    });
+
+    it("is infinite at the ends of its domain", function () {
+        assert.equal(ss.inverseErrorFunction(1), Infinity);
+        assert.equal(ss.inverseErrorFunction(-1), -Infinity);
+    });
+
+    it("is not a number outside its domain", function () {
+        assert.equal(Number.isNaN(ss.inverseErrorFunction(1.5)), true);
+        assert.equal(Number.isNaN(ss.inverseErrorFunction(-1.5)), true);
+    });
+});


### PR DESCRIPTION
`inverseErrorFunction` returns the Winitzki approximation and stops there. Its round-trip error through `errorFunction` reaches 3.3e-4, and the existing test in `error_function.test.js` allows 4e-4, so it passes with about 18% of the tolerance to spare.

`probit` is built on it and inherits the error at full size:

```
probit(0.975)   1.9571619317   published 1.9599639845
probit(0.99)    2.3213677049   published 2.3263478740
probit(0.999)   3.0801321223   published 3.0902323062
```

The 95% two-sided z is the value most users of `probit` reach for, and it comes back as 1.957.

`errorFunction` itself is accurate to 7.9e-8 here, so the seed can simply be refined against it. Two Newton steps, using `2 / sqrt(pi) * exp(-x^2)` for the derivative:

```
round trip max     3.284e-4  ->  8.301e-8
probit max error   1.010e-2  ->  5.669e-8
```

`probit(0.975)` is now 1.9599639471.

Infinity at the ends, `NaN` outside the domain, oddness, and `inverseErrorFunction(0) === 0` are all preserved. The zero case is guarded, because `errorFunction(0)` is off by 3e-8 and the refinement would otherwise walk an exact answer away from zero.

No existing expectation changed. `npm test` goes 313 passing to 318, 0 failing.

Reference values in the new test come from inverting a Maclaurin series for `erf` by bisection, residual ~1e-16.

Not addressed: the `21 * epsilon` tolerance in `cumulative.test.js`. That slack is the 0.01 granularity of `standardNormalTable`, not this function. It measures 2.000e-3 both before and after.
