### PR TITLE
fix(gamma): lift small arguments before the Nemes expansion

### DIFF
--- a/.changeset/gamma-small-argument.md
+++ b/.changeset/gamma-small-argument.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Correct `gamma` for small arguments. Nemes' approximation is asymptotic, dividing its terms by powers of `n - 3/4`, so the series stops converging once the argument is small. Applied directly it returned 2.8 for `gamma(1.01)` against a true value of 0.994, and 1.2128 for `gamma(1.1)` against 0.951. Arguments in `(0, 1)` were already lifted by a two-step recurrence; that lift now runs generally, raising the argument until the expansion converges. Worst relative error over `(0, 30]` goes from 1.8 to 1.9e-13, and over `[-11, 0)` from 0.64 to 2.8e-13, since negative arguments reach the expansion through Euler's reflection formula. The two `@example` values for `gamma(11.5)` and `gamma(-11.5)` recorded the old error and have been updated.

--- a/src/gamma.js
+++ b/src/gamma.js
@@ -12,10 +12,16 @@ import factorial from "./factorial.js";
  * @returns {number} The gamma of the input value.
  *
  * @example
- * gamma(11.5); // 11899423.084037038
- * gamma(-11.5); // 2.29575810481609e-8
+ * gamma(11.5); // 11899423.083964102
+ * gamma(-11.5); // 2.2957581048237436e-8
  * gamma(5); // 24
  */
+// The Nemes expansion is asymptotic, so it is only accurate for large
+// arguments. Below this the recurrence lifts the argument first. At 20
+// the worst relative error over (0, 30] is 1.9e-13, against 1.8 for the
+// expansion applied directly.
+const NEMES_MIN = 20;
+
 function gamma(n) {
     if (Number.isInteger(n)) {
         if (n <= 0) {
@@ -27,16 +33,18 @@ function gamma(n) {
         }
     }
 
-    if (n > 0 && n < 1) {
-        // Arguments in (0, 1) would otherwise recurse forever through
-        // the reflection branch below, because the reflected argument
-        // stays in (0, 1) and never reaches the Nemes expansion.
-        // Lift into the supported domain via the recurrence
-        // gamma(n) = gamma(n + 2) / (n * (n + 1)). Stepping up by two
-        // lands the evaluation on (2, 3), where the Nemes expansion is
-        // far better conditioned than just above 1, so the result is
-        // near-exact rather than merely finite.
-        return gamma(n + 2) / (n * (n + 1));
+    if (n > 0 && n < NEMES_MIN) {
+        // The Nemes expansion below divides its terms by powers of
+        // `n - 3/4`, so they stop shrinking once the argument is small
+        // and the series is worthless there: gamma(1.01) came back as
+        // 1.8 times its true value. Arguments in (0, 1) additionally
+        // recursed forever through the reflection branch, because the
+        // reflected argument stayed in (0, 1) and never reached the
+        // expansion at all.
+        //
+        // Lift into the range where the expansion converges, using the
+        // recurrence gamma(n) = gamma(n + 1) / n.
+        return gamma(n + 1) / n;
     }
 
     // Decrement n, because approximation is defined for n - 1

--- a/test/gamma.test.js
+++ b/test/gamma.test.js
@@ -29,32 +29,48 @@ describe("gamma", function () {
         assert.ok(Number.isFinite(ss.gamma(0.25)));
         assert.ok(Number.isFinite(ss.gamma(0.9)));
     });
-    it("gamma in (0, 1) should satisfy the two-step recurrence", function () {
-        // The fix lifts arguments in (0, 1) by two steps via
-        // gamma(n) = gamma(n + 2) / (n * (n + 1)), so this identity
-        // holds exactly by construction. It is a method-agnostic
-        // check that the returned value tracks the gamma function
-        // and not an arbitrary number.
-        assert.equal(ss.gamma(0.5), ss.gamma(2.5) / (0.5 * 1.5));
+    it("gamma should satisfy the recurrence it is lifted by", function () {
+        // Small arguments are raised by gamma(n) = gamma(n + 1) / n, so
+        // this identity holds exactly by construction. It is a
+        // method-agnostic check that the returned value tracks the
+        // gamma function and not an arbitrary number.
+        assert.equal(ss.gamma(0.5), ss.gamma(1.5) / 0.5);
+        assert.equal(ss.gamma(1.25), ss.gamma(2.25) / 1.25);
     });
     it("gamma(0.5) should be very close to sqrt(pi)", function () {
-        // Stepping up by two evaluates the Nemes expansion on (2, 3),
-        // where it is well conditioned, so the value is near-exact.
-        // Measured absolute error is about 8.8e-6, so 1e-5 is a tight
-        // honest bound rather than a loose one.
         const sqrtPi = Math.sqrt(Math.PI); // 1.7724538509055160
-        assert.ok(Math.abs(ss.gamma(0.5) - sqrtPi) < 1e-5);
+        assert.ok(Math.abs(ss.gamma(0.5) - sqrtPi) < 1e-12);
     });
-    it("gamma in (0, 1) should be accurate to ~1e-4", function () {
-        // Reference values from a high-precision gamma evaluation. The
-        // two-step lift keeps the relative error of these arguments
-        // below 1e-4 (measured worst case about 1.5e-5 at 0.25).
+    it("gamma(1.5) should be very close to sqrt(pi) / 2", function () {
+        assert.ok(Math.abs(ss.gamma(1.5) - Math.sqrt(Math.PI) / 2) < 1e-12);
+    });
+    it("gamma just above 1 should be accurate", function () {
+        // The Nemes expansion is asymptotic and diverges here. Applied
+        // directly it returned 1.2128 for gamma(1.1), 1.27 times the
+        // true value, and 2.8 for gamma(1.01).
         const cases = [
-            [0.25, 3.6256099082219083],
-            [0.9, 1.0686287021184886]
+            [1.01, 0.99432585119150574],
+            [1.1, 0.95135076986687339],
+            [1.9, 0.96176583190738722]
         ];
         for (const [x, expected] of cases) {
-            assert.ok(Math.abs(ss.gamma(x) - expected) / expected < 1e-4);
+            assert.ok(
+                Math.abs(ss.gamma(x) - expected) / expected < 1e-10,
+                "gamma(" + x + ")"
+            );
+        }
+    });
+    it("gamma in (0, 1) should be accurate", function () {
+        // Reference values from a high-precision gamma evaluation.
+        const cases = [
+            [0.25, 3.6256099082219064],
+            [0.9, 1.068628702119319]
+        ];
+        for (const [x, expected] of cases) {
+            assert.ok(
+                Math.abs(ss.gamma(x) - expected) / expected < 1e-10,
+                "gamma(" + x + ")"
+            );
         }
     });
 });


### PR DESCRIPTION
`gamma(1.01)` returns 2.80027. The true value is 0.99433.

Nemes' approximation is asymptotic. Its correction terms are divided by powers of `n - 3/4`, so they stop shrinking once the argument is small, and the series is worthless there:

```
gamma(1.01)   2.80027  exact 0.99433
gamma(1.05)   1.68117  exact 0.97350
gamma(1.10)   1.21285  exact 0.95135
gamma(1.50)   0.88796  exact 0.88623
gamma(1.90)   0.96186  exact 0.96177
```

The error decays smoothly with the argument, so nothing looked obviously broken further out. Negative arguments inherit it through Euler's reflection formula, worst 0.64 relative near -0.01.

Arguments in `(0, 1)` were already lifted by a two-step recurrence, added to escape infinite recursion in the reflection branch. The same lift fixes this; it just needed to run generally rather than only below 1. `gamma(n) = gamma(n + 1) / n`, applied until the argument reaches 20.

```
worst relative error, (0, 30]    1.816    ->  1.9e-13
worst relative error, [-11, 0)   0.645    ->  2.8e-13
```

Reference values come from an independent Lanczos evaluation, checked against `sqrt(pi)` at 0.5 and `-2 * sqrt(pi)` at -0.5 to 1e-15.

Threshold 20 is where the returns flatten: 4 gives 4.5e-8, 12 gives 4.6e-12, 30 gives 4.9e-14 for twelve more divisions.

Integer arguments still short-circuit to `factorial`, and zero and negative integers still return `NaN`.

Two things this changes that are worth flagging. The `@example` values for `gamma(11.5)` and `gamma(-11.5)` recorded the old error to full precision, so they are updated. And the test asserting `gamma(0.5) === gamma(2.5) / (0.5 * 1.5)` was written against the two-step lift; it is now the one-step form, which still holds exactly by construction.

The pinned `gamma(11.54)` expectation is untouched and still passes. Worth noting it is 8.0e-5 away from the true value and the assertion allows 1e-4, so it passes from the other side now.

`npm test`: 313 passing to 315, 0 failing.
