### PR TITLE
feat(skewness): add an opt-in biased coefficient

### DIFF
--- a/.changeset/biased-sample-skewness.md
+++ b/.changeset/biased-sample-skewness.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+`sampleSkewness` accepts a `biased` flag. Passing `true` returns the biased coefficient, the population moment ratio `m3 / m2^(3/2)`, which is what R reports and what `scipy.stats.skew` returns by default. The existing adjusted Fisher-Pearson coefficient stays the default and is unchanged, so this is opt-in. Closes #167.

--- a/src/sample_skewness.d.ts
+++ b/src/sample_skewness.d.ts
@@ -1,6 +1,6 @@
 /**
  * https://simple-statistics.github.io/docs/#sampleskewness
  */
-declare function sampleSkewness(x: readonly number[]): number;
+declare function sampleSkewness(x: readonly number[], biased?: boolean): number;
 
 export default sampleSkewness;

--- a/src/sample_skewness.js
+++ b/src/sample_skewness.js
@@ -10,14 +10,21 @@ import mean from "./mean.js";
  * moment coefficient, which is the version found in Excel and several
  * statistical packages including Minitab, SAS and SPSS.
  *
+ * Pass `biased` to opt into the biased coefficient instead, which is the
+ * population moment ratio `m3 / m2^(3/2)`. That is what R reports and what
+ * scipy returns by default; the adjusted coefficient above is scipy's
+ * `bias=False`. The two differ by a factor of `sqrt(n * (n - 1)) / (n - 2)`.
+ *
  * @since 4.1.0
  * @param {Array<number>} x a sample of 3 or more data points
+ * @param {boolean} [biased=false] if true, return the biased coefficient
  * @returns {number} sample skewness
  * @throws {Error} if x has length less than 3
  * @example
  * sampleSkewness([2, 4, 6, 3, 1]); // => 0.590128656384365
+ * sampleSkewness([2, 4, 6, 3, 1], true); // => 0.3958703373438167
  */
-function sampleSkewness(x) {
+function sampleSkewness(x, biased = false) {
     if (x.length < 3) {
         throw new Error("sampleSkewness requires at least three data points");
     }
@@ -33,6 +40,18 @@ function sampleSkewness(x) {
         sumCubedDeviations += tempValue * tempValue * tempValue;
     }
 
+    const n = x.length;
+
+    if (biased) {
+        // The population moments, without Bessel's correction: the biased
+        // coefficient is the third central moment over the second raised
+        // to three halves.
+        const secondCentralMoment = sumSquaredDeviations / n;
+        const thirdCentralMoment = sumCubedDeviations / n;
+
+        return thirdCentralMoment / Math.pow(secondCentralMoment, 3 / 2);
+    }
+
     // this is Bessels' Correction: an adjustment made to sample statistics
     // that allows for the reduced degree of freedom entailed in calculating
     // values from samples rather than complete populations.
@@ -43,7 +62,6 @@ function sampleSkewness(x) {
         sumSquaredDeviations / besselsCorrection
     );
 
-    const n = x.length;
     const cubedS = Math.pow(theSampleStandardDeviation, 3);
 
     return (n * sumCubedDeviations) / ((n - 1) * (n - 2) * cubedS);

--- a/test/sample_skewness.test.js
+++ b/test/sample_skewness.test.js
@@ -44,4 +44,41 @@ describe("sample skewness", function () {
         const data = Object.freeze([2, 0, 0]);
         assert.equal(+ss.sampleSkewness(data).toPrecision(10), 1.732050808);
     });
+
+    it("can calculate the biased skewness", function () {
+        // Expected values from scipy.stats.skew(data, bias=True), which is
+        // also what R reports. The unadjusted values above are the same
+        // call with bias=False.
+        const cases = [
+            [[2, 4, 6, 3, 1], 0.3958703373438167],
+            [[1, 1, 2, 3, 8], 1.2181208646399415],
+            [[2, 4, 4, 4, 5, 5, 7, 9], 0.65625],
+            [[10, 20, 30, 40, 100], 1.1384199576606167]
+        ];
+        for (const [data, expected] of cases) {
+            assert.equal(
+                Math.abs(ss.sampleSkewness(data, true) - expected) < 1e-14,
+                true,
+                JSON.stringify(data)
+            );
+        }
+    });
+
+    it("biased and unadjusted skewness differ by the known factor", function () {
+        // G1 = g1 * sqrt(n * (n - 1)) / (n - 2)
+        const data = Object.freeze([1, 1, 2, 3, 8, 13, 21]);
+        const n = data.length;
+        const factor = Math.sqrt(n * (n - 1)) / (n - 2);
+        assert.equal(
+            Math.abs(
+                ss.sampleSkewness(data) - ss.sampleSkewness(data, true) * factor
+            ) < 1e-14,
+            true
+        );
+    });
+
+    it("defaults to the unadjusted coefficient", function () {
+        const data = Object.freeze([2, 4, 6, 3, 1]);
+        assert.equal(ss.sampleSkewness(data), ss.sampleSkewness(data, false));
+    });
 });


### PR DESCRIPTION
Closes #167.

`sampleSkewness` takes a `biased` flag. `true` returns the population moment ratio `m3 / m2^(3/2)`, which is what R reports and what `scipy.stats.skew` returns by default. The current adjusted Fisher-Pearson coefficient stays the default, so this is opt-in as the issue asks.

```js
sampleSkewness([2, 4, 6, 3, 1]);        // 0.590128656384365
sampleSkewness([2, 4, 6, 3, 1], true);  // 0.3958703373438167
```

The signature follows `normalDistribution(x, mean, standardDeviation, cumulative)`, the existing trailing-flag pattern in the library.

Checked against `scipy.stats.skew` 1.18.0 on six samples, both modes. Worst disagreement is 6.7e-16 for the default and 2.2e-16 for the new path. That run also confirms the current default is exactly scipy's `bias=False`, which the docstring now says.

The two coefficients differ by `sqrt(n * (n - 1)) / (n - 2)`, and there is a test asserting that identity so the branches cannot drift apart.

The default code path is untouched. I ran the six samples before and after the change and the returned doubles are bit-identical, so nothing depending on current behaviour moves.

One thing I did not change: the `n >= 3` requirement still applies in both modes. The biased coefficient is defined at `n = 2`, so that throw is stricter than it needs to be, but relaxing it is a separate decision about the function's contract and the issue does not ask for it.

`npm test`: 313 passing to 316, 0 failing.
