### PR TITLE
feat(root-mean-square): add scaledRootMeanSquare for extreme magnitudes

### DIFF
--- a/.changeset/scaled-root-mean-square.md
+++ b/.changeset/scaled-root-mean-square.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+Add `scaledRootMeanSquare`, an equivalent way of computing the root mean square for values whose squares leave floating point range. `rootMeanSquare` sums the squares directly, so it returns `Infinity` above roughly 1e154 and `0` below roughly 1e-162. The new function divides through by the largest magnitude first. `rootMeanSquare` is unchanged, following the same split as `geometricMean` and `logAverage`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ export {
     default as rootMeanSquare,
     default as rms
 } from "./src/root_mean_square";
+export { default as scaledRootMeanSquare } from "./src/scaled_root_mean_square";
 export { default as sample } from "./src/sample";
 export { default as sampleCorrelation } from "./src/sample_correlation";
 // sample statistics

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ export { default as sampleSkewness } from "./src/sample_skewness.js";
 export { default as sampleStandardDeviation } from "./src/sample_standard_deviation.js";
 export { default as sampleVariance } from "./src/sample_variance.js";
 export { default as sampleWithReplacement } from "./src/sample_with_replacement.js";
+export { default as scaledRootMeanSquare } from "./src/scaled_root_mean_square.js";
 export { default as shuffle } from "./src/shuffle.js";
 export { default as shuffleInPlace } from "./src/shuffle_in_place.js";
 export { default as standardDeviation } from "./src/standard_deviation.js";

--- a/src/scaled_root_mean_square.d.ts
+++ b/src/scaled_root_mean_square.d.ts
@@ -1,0 +1,6 @@
+/**
+ * https://simple-statistics.github.io/docs/#scaledrootmeansquare
+ */
+declare function scaledRootMeanSquare(x: readonly number[]): number;
+
+export default scaledRootMeanSquare;

--- a/src/scaled_root_mean_square.js
+++ b/src/scaled_root_mean_square.js
@@ -1,0 +1,58 @@
+/**
+ * The [root mean square](https://en.wikipedia.org/wiki/Root_mean_square)
+ * computed by scaling, which is an equivalent way of computing
+ * `rootMeanSquare` suitable for values whose squares leave floating point
+ * range.
+ *
+ * `rootMeanSquare` sums the squares directly, so it returns `Infinity` once
+ * a value exceeds about 1e154 and `0` once every value falls below about
+ * 1e-162. This function divides through by the largest magnitude first, so
+ * the squares it sums are all at most one.
+ *
+ * It runs in `O(n)`, linear time, with respect to the length of the array,
+ * in two passes rather than one.
+ *
+ * @param {Array<number>} x a sample of one or more data points
+ * @returns {number} root mean square
+ * @throws {Error} if x is empty
+ * @example
+ * scaledRootMeanSquare([-1, 1, -1, 1]); // => 1
+ * scaledRootMeanSquare([1e200, 2e200, 3e200]); // => 2.1602468994692866e+200
+ */
+function scaledRootMeanSquare(x) {
+    if (x.length === 0) {
+        throw new Error(
+            "scaledRootMeanSquare requires at least one data point"
+        );
+    }
+
+    let max = 0;
+    for (let i = 0; i < x.length; i++) {
+        const magnitude = Math.abs(x[i]);
+        if (magnitude > max) {
+            max = magnitude;
+        }
+    }
+
+    // Every value is zero, and the division below would be 0 / 0.
+    if (max === 0) {
+        return 0;
+    }
+
+    // An infinite or missing largest value cannot be scaled away, and
+    // dividing by it would turn the result into NaN. Report it as
+    // `rootMeanSquare` does.
+    if (!Number.isFinite(max)) {
+        return max;
+    }
+
+    let sumOfSquares = 0;
+    for (let i = 0; i < x.length; i++) {
+        const scaled = x[i] / max;
+        sumOfSquares += scaled * scaled;
+    }
+
+    return max * Math.sqrt(sumOfSquares / x.length);
+}
+
+export default scaledRootMeanSquare;

--- a/test/scaled_root_mean_square.test.js
+++ b/test/scaled_root_mean_square.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as ss from "../index.js";
+
+describe("scaledRootMeanSquare", function () {
+    it("agrees with rootMeanSquare on ordinary input", function () {
+        const cases = [[-1, 1, -1, 1], [1, 2, 3, 4], [-3, 4], [7], [0, 0, 0]];
+        for (const x of cases) {
+            assert.equal(
+                ss.scaledRootMeanSquare(x),
+                ss.rootMeanSquare(x),
+                JSON.stringify(x)
+            );
+        }
+    });
+
+    it("stays finite where the squares leave range", function () {
+        // sqrt((1 + 4 + 9) / 3) * 1e200
+        const expected = Math.sqrt(14 / 3) * 1e200;
+        const actual = ss.scaledRootMeanSquare([1e200, 2e200, 3e200]);
+        assert.equal(Math.abs(actual - expected) / expected < 1e-15, true);
+        assert.equal(ss.rootMeanSquare([1e200, 2e200, 3e200]), Infinity);
+    });
+
+    it("stays nonzero where the squares underflow", function () {
+        const expected = Math.sqrt(14 / 3) * 1e-200;
+        const actual = ss.scaledRootMeanSquare([1e-200, 2e-200, 3e-200]);
+        assert.equal(Math.abs(actual - expected) / expected < 1e-15, true);
+        assert.equal(ss.rootMeanSquare([1e-200, 2e-200, 3e-200]), 0);
+    });
+
+    it("reports infinite and missing values as rootMeanSquare does", function () {
+        assert.equal(
+            ss.scaledRootMeanSquare([Number.POSITIVE_INFINITY, 1]),
+            Number.POSITIVE_INFINITY
+        );
+        assert.equal(
+            Number.isNaN(ss.scaledRootMeanSquare([Number.NaN, 1])),
+            true
+        );
+    });
+
+    it("throws on empty input", function () {
+        assert.throws(function () {
+            ss.scaledRootMeanSquare([]);
+        }, /at least one data point/);
+    });
+});


### PR DESCRIPTION
Taking you up on #838, where you closed my in-place fix with:

> I think exposing a _new_ method that uses scaled values would make sense, but to add a silent fallback behavior that re-does the computation in the existing method seems like it is too 'magic' and too implicit

So this adds `scaledRootMeanSquare` and leaves `rootMeanSquare` completely alone. It is the same split the library already has between `geometricMean` and `logAverage`, whose docstring likewise says it is the form "suitable for large or small products".

```
                          rootMeanSquare   scaledRootMeanSquare
[1e200, 2e200, 3e200]     Infinity         2.1602468994692866e+200
[1e-200, 2e-200, 3e-200]  0                2.1602468994692867e-200
[1, 2, 3, 4]              2.7386127875258306   same
[-1, 1, -1, 1]            1                same
```

The exact value for the first row is `sqrt(14/3) * 1e200`, and the returned double is within 1e-15 relative of it. Direct summation breaks above roughly 1e154 and below roughly 1e-162.

Two implementation notes.

`Math.hypot` is scale-safe and would give `Math.hypot(...x) / Math.sqrt(x.length)` in one line, but the spread throws `RangeError: Maximum call stack size exceeded` on a 200,000 element array, so it is not usable for a statistics library. The explicit two-pass loop handles that array fine.

Infinite and `NaN` inputs return what `rootMeanSquare` returns rather than turning into `NaN` through the scaling, and the empty-input throw matches too. There is a test pinning that parity.

The name is the part I am least confident about, so rename it to whatever fits and I will follow.

`npm test`: 313 passing to 318, 0 failing.
