### PR TITLE
feat(regression): add weightedLinearRegression

### DIFF
--- a/.changeset/weighted-linear-regression.md
+++ b/.changeset/weighted-linear-regression.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": minor
+---
+
+Add `weightedLinearRegression`, which fits a line by [weighted least squares](https://en.wikipedia.org/wiki/Weighted_least_squares), the same thing R's `lm()` does when given a `weights` argument. `linearRegression` is the special case where every weight is equal, and it is unchanged. Validation reuses the same helper as the other weighted functions. Closes #48.

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ export { default as tTest } from "./src/t_test";
 export { default as tTestTwoSample } from "./src/t_test_two_sample";
 export { default as uniqueCountSorted } from "./src/unique_count_sorted";
 export { default as variance } from "./src/variance";
+export { default as weightedLinearRegression } from "./src/weighted_linear_regression";
 export { default as weightedMean } from "./src/weighted_mean";
 export { default as weightedQuantile } from "./src/weighted_quantile";
 export { default as weightedStandardDeviation } from "./src/weighted_standard_deviation";

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ export { default as tTest } from "./src/t_test.js";
 export { default as tTestTwoSample } from "./src/t_test_two_sample.js";
 export { default as uniqueCountSorted } from "./src/unique_count_sorted.js";
 export { default as variance } from "./src/variance.js";
+export { default as weightedLinearRegression } from "./src/weighted_linear_regression.js";
 export { default as weightedMean } from "./src/weighted_mean.js";
 export { default as weightedQuantile } from "./src/weighted_quantile.js";
 export { default as weightedStandardDeviation } from "./src/weighted_standard_deviation.js";

--- a/src/weighted_linear_regression.d.ts
+++ b/src/weighted_linear_regression.d.ts
@@ -1,0 +1,9 @@
+/**
+ * https://simple-statistics.github.io/docs/#weightedlinearregression
+ */
+declare function weightedLinearRegression(
+    data: readonly (readonly number[])[],
+    weights: readonly number[]
+): { m: number; b: number };
+
+export default weightedLinearRegression;

--- a/src/weighted_linear_regression.js
+++ b/src/weighted_linear_regression.js
@@ -1,0 +1,59 @@
+import validateWeightedInput from "./validate_weighted_input.js";
+
+/**
+ * [Weighted least squares](https://en.wikipedia.org/wiki/Weighted_least_squares)
+ * fits a line through a set of coordinates in which some observations count
+ * for more than others, which is what R's `lm()` does when given a `weights`
+ * argument. `linearRegression` is the special case where every weight is
+ * equal.
+ *
+ * A weight of zero drops its observation from the fit. Weights are relative,
+ * so scaling all of them by the same factor leaves the line unchanged.
+ *
+ * @param {Array<Array<number>>} data an array of two-element arrays,
+ * like `[[0, 1], [2, 3]]`
+ * @param {Array<number>} weights weight for each coordinate
+ * @returns {Object} object containing slope and intersect of regression line
+ * @throws {Error} if data is empty, weights is a different length than data,
+ * all weights are zero, or a weight is negative
+ * @example
+ * weightedLinearRegression([[0, 0], [1, 1], [2, 2]], [1, 1, 1]); // => { m: 1, b: 0 }
+ */
+function weightedLinearRegression(data, weights) {
+    const totalWeight = validateWeightedInput(
+        data,
+        weights,
+        "weightedLinearRegression"
+    );
+
+    // With one point the slope is unconstrained, so match `linearRegression`
+    // and take the horizontal line through it.
+    if (data.length === 1) {
+        return { m: 0, b: data[0][1] };
+    }
+
+    // The weighted means of x and y. Centering on them before accumulating
+    // the cross products keeps the sums small when the coordinates are not.
+    let sumWeightedX = 0;
+    let sumWeightedY = 0;
+    for (let i = 0; i < data.length; i++) {
+        sumWeightedX += weights[i] * data[i][0];
+        sumWeightedY += weights[i] * data[i][1];
+    }
+    const meanX = sumWeightedX / totalWeight;
+    const meanY = sumWeightedY / totalWeight;
+
+    let sumXY = 0;
+    let sumXX = 0;
+    for (let i = 0; i < data.length; i++) {
+        const deviationX = data[i][0] - meanX;
+        sumXY += weights[i] * deviationX * (data[i][1] - meanY);
+        sumXX += weights[i] * deviationX * deviationX;
+    }
+
+    const m = sumXY / sumXX;
+
+    return { m: m, b: meanY - m * meanX };
+}
+
+export default weightedLinearRegression;

--- a/test/weighted_linear_regression.test.js
+++ b/test/weighted_linear_regression.test.js
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as ss from "../index.js";
+
+describe("weightedLinearRegression", function () {
+    it("equals linearRegression when the weights are equal", function () {
+        const data = [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 5]
+        ];
+        const plain = ss.linearRegression(data);
+        for (const w of [1, 4, 0.25]) {
+            const weighted = ss.weightedLinearRegression(
+                data,
+                data.map(() => w)
+            );
+            assert.equal(weighted.m, plain.m);
+            assert.equal(weighted.b, plain.b);
+        }
+    });
+
+    it("matches a weighted least squares reference", function () {
+        // Expected values from statsmodels.api.WLS.
+        const data = [
+            [1, 2],
+            [2, 3],
+            [3, 5],
+            [4, 4],
+            [5, 8]
+        ];
+        const { m, b } = ss.weightedLinearRegression(data, [5, 1, 1, 1, 5]);
+        assert.equal(Math.abs(m - 1.4523809523809523) < 1e-12, true);
+        assert.equal(Math.abs(b - 0.4120879120879124) < 1e-12, true);
+    });
+
+    it("a zero weight drops its observation", function () {
+        const data = [
+            [0, 1],
+            [1, 3],
+            [2, 4],
+            [3, 8],
+            [4, 9]
+        ];
+        const dropped = ss.weightedLinearRegression(data, [0, 1, 1, 1, 1]);
+        const without = ss.linearRegression(data.slice(1));
+        assert.equal(dropped.m, without.m);
+        assert.equal(dropped.b, without.b);
+    });
+
+    it("integer weights match repeating the observations", function () {
+        const weighted = ss.weightedLinearRegression(
+            [
+                [1, 2],
+                [2, 3],
+                [3, 5]
+            ],
+            [1, 2, 1]
+        );
+        const repeated = ss.linearRegression([
+            [1, 2],
+            [2, 3],
+            [2, 3],
+            [3, 5]
+        ]);
+        assert.equal(weighted.m, repeated.m);
+        assert.equal(weighted.b, repeated.b);
+    });
+
+    it("is unchanged when every weight is scaled", function () {
+        const data = [
+            [0, 1],
+            [1, 3],
+            [2, 4],
+            [3, 8],
+            [4, 9]
+        ];
+        const small = ss.weightedLinearRegression(data, [1, 2, 3, 4, 5]);
+        const large = ss.weightedLinearRegression(data, [10, 20, 30, 40, 50]);
+        assert.equal(Math.abs(small.m - large.m) < 1e-12, true);
+        assert.equal(Math.abs(small.b - large.b) < 1e-12, true);
+    });
+
+    it("takes the horizontal line through a single point", function () {
+        assert.deepEqual(ss.weightedLinearRegression([[5, 7]], [3]), {
+            m: 0,
+            b: 7
+        });
+    });
+
+    it("rejects invalid input", function () {
+        assert.throws(function () {
+            ss.weightedLinearRegression([], []);
+        }, /at least one data point/);
+        assert.throws(function () {
+            ss.weightedLinearRegression(
+                [
+                    [0, 0],
+                    [1, 1]
+                ],
+                [1]
+            );
+        }, /same length/);
+        assert.throws(function () {
+            ss.weightedLinearRegression(
+                [
+                    [0, 0],
+                    [1, 1]
+                ],
+                [-1, 2]
+            );
+        }, /non-negative/);
+        assert.throws(function () {
+            ss.weightedLinearRegression(
+                [
+                    [0, 0],
+                    [1, 1]
+                ],
+                [0, 0]
+            );
+        }, /positive weight/);
+    });
+});


### PR DESCRIPTION
Closes #48, where you said you would accept a patch for this. The references you gave there, R's `lm()` and the weighted least squares article, are what it follows.

`linearRegression` is untouched. This is a separate function, so it does not collide with #843.

Checked against `statsmodels.api.WLS` on six datasets, including unequal weights, a zero weight, fractional weights and coordinates at 1e6. Worst slope disagreement is 1.4e-15 and worst intercept disagreement is 7e-16 relative.

Four identities hold exactly rather than approximately, and each has a test:

```
equal weights            == linearRegression                    exact
weights [0,1,1,1,1]      == linearRegression on the last four   exact
weights [1,2,1]          == linearRegression with point 2 twice exact
one point                => { m: 0, b: y }, matching linearRegression
```

Scaling every weight by the same factor leaves the line unchanged to 1e-12, which is a tolerance rather than an equality because the sums are reassociated.

Validation goes through `validateWeightedInput`, the helper `weightedMean` and the others already use, so the error messages and the empty, length-mismatch, negative-weight and all-zero-weight cases match the rest of the weighted family for free.

Implementation note: it centres on the weighted means before accumulating the cross products rather than summing raw `x*y`, which is why the 1e6 case still agrees to the last couple of bits.

`npm test`: 313 passing to 320, 0 failing.
