### PR TITLE
fix(regression): center linearRegression on the means before accumulating

### DIFF
--- a/.changeset/linear-regression-cancellation.md
+++ b/.changeset/linear-regression-cancellation.md
@@ -1,0 +1,5 @@
+---
+"simple-statistics": patch
+---
+
+Fix `linearRegression` losing precision when the x values share a large offset. The one-pass normal equations subtract two large and nearly equal quantities, so cancellation destroys the variance: on a perfect line the slope came back 22% low for x near 1e8, changed sign at 1e9, and was `Infinity` at 1e10. Timestamps reach this in ordinary use, and with `Date.now()` as x the slope was 69% wrong. The cross products are now accumulated from deviations about the means, which is what `weightedLinearRegression` and `sampleVariance` already do, at the cost of a second pass over the data. `weightedLinearRegression` documents `linearRegression` as the special case where every weight is equal; the two disagreed at large x and now agree.

--- a/src/linear_regression.js
+++ b/src/linear_regression.js
@@ -24,43 +24,29 @@ function linearRegression(data) {
         m = 0;
         b = data[0][1];
     } else {
-        // Initialize our sums and scope the `m` and `b`
-        // variables that define the line.
+        // The means of x and y. Centering on them before accumulating the
+        // cross products keeps the sums small when the coordinates are not,
+        // which is what `weightedLinearRegression` already does.
         let sumX = 0;
         let sumY = 0;
-        let sumXX = 0;
-        let sumXY = 0;
-
-        // Use local variables to grab point values
-        // with minimal object property lookups
-        let point;
-        let x;
-        let y;
-
-        // Gather the sum of all x values, the sum of all
-        // y values, and the sum of x^2 and (x*y) for each
-        // value.
-        //
-        // In math notation, these would be SS_x, SS_y, SS_xx, and SS_xy
         for (let i = 0; i < dataLength; i++) {
-            point = data[i];
-            x = point[0];
-            y = point[1];
+            sumX += data[i][0];
+            sumY += data[i][1];
+        }
+        const meanX = sumX / dataLength;
+        const meanY = sumY / dataLength;
 
-            sumX += x;
-            sumY += y;
-
-            sumXX += x * x;
-            sumXY += x * y;
+        let sumXY = 0;
+        let sumXX = 0;
+        for (let i = 0; i < dataLength; i++) {
+            const deviationX = data[i][0] - meanX;
+            sumXY += deviationX * (data[i][1] - meanY);
+            sumXX += deviationX * deviationX;
         }
 
-        // `m` is the slope of the regression line
-        m =
-            (dataLength * sumXY - sumX * sumY) /
-            (dataLength * sumXX - sumX * sumX);
-
-        // `b` is the y-intercept of the line.
-        b = sumY / dataLength - (m * sumX) / dataLength;
+        // `m` is the slope of the regression line, `b` its y-intercept.
+        m = sumXY / sumXX;
+        b = meanY - m * meanX;
     }
 
     // Return both values as an object.

--- a/test/linear_regression.test.js
+++ b/test/linear_regression.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { linearRegression, linearRegressionLine } from "../index.js";
+import {
+    linearRegression,
+    linearRegressionLine,
+    weightedLinearRegression
+} from "../index.js";
 
 describe("linear regression", function () {
     it("correctly generates a line for a 0, 0 to 1, 1 dataset", function () {
@@ -59,6 +63,33 @@ describe("linear regression", function () {
                 [1, 10]
             ]),
             { m: -10, b: 20 }
+        );
+    });
+
+    it("keeps its precision when x values share a large offset", function () {
+        // A perfect line y = 2x + 1, shifted so the x values are the size of
+        // a millisecond timestamp. The naive sums lose every significant
+        // digit of the variance to cancellation.
+        const data = [];
+        for (let i = 0; i < 5; i++) {
+            data.push([1e11 + i, 2 * i + 1]);
+        }
+        const { m, b } = linearRegression(data);
+        assert.equal(m, 2);
+        assert.equal(b, 1 - 2 * 1e11);
+    });
+
+    it("agrees with weightedLinearRegression when the weights are equal", function () {
+        const data = [];
+        for (let i = 0; i < 5; i++) {
+            data.push([1e9 + i, 2 * i + 1]);
+        }
+        const weights = data.map(function () {
+            return 1;
+        });
+        assert.deepEqual(
+            linearRegression(data),
+            weightedLinearRegression(data, weights)
         );
     });
 });


### PR DESCRIPTION
`linearRegression` accumulates raw sums for the normal equations, so the variance is lost to cancellation once the x values share a large offset. On a perfect line the slope comes back 22% low at x near 1e8, changes sign at 1e9, and is `Infinity` at 1e10. Timestamps hit this in ordinary use: with `Date.now()` as x the slope is 69% wrong.

This accumulates the cross products from deviations about the means instead, which is what `weightedLinearRegression` and `sampleVariance` already do here. It costs a second pass over the data.

`weightedLinearRegression`'s documentation says `linearRegression` is the special case where every weight is equal. The two disagreed at large x; the second added test pins them together.

Before:

```
actual: Infinity,
expected: 2,
```

After: 335 passing, 0 failing, up from 333 on `main` plus the two added tests. `npm run lint` is clean.
